### PR TITLE
Fix: Update manifest.json to remove pages-list.html and pages-list.js…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,8 +78,6 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "pages-list.html",
-        "pages-list.js",
         "images/icon48.png"
       ],
       "matches": [


### PR DESCRIPTION
… from web_accessible_resources which exposes these privileged extension pages to all sites, creating a privacy leak risk.

This exposure of extension HTML/JS via 'web_accessible_resources' can allow any website to open a privileged extension page and potentially leak user highlight data.

Impact: Any website can load 'pages-list.html' from the extension origin. Because that page runs with extension privileges, it can read extension storage and display a user’s highlight history, creating a privacy leak and raising the risk of UI redress/clickjacking against privileged UI.