### PR TITLE
Add E2E tests for sync requirements

### DIFF
--- a/e2e-tests/sync.spec.js
+++ b/e2e-tests/sync.spec.js
@@ -89,6 +89,253 @@ test.describe('Sync scenarios', () => {
     expect(local[`${url}_meta`]).toBeUndefined();
   });
 
+  test('M-2: Propagation of new highlights from sync to local and UI', async ({ page, background }) => {
+    const url = `file://${path.join(__dirname, 'test-page.html')}`;
+    await page.goto(url);
+    const syncKey = urlToSyncKey(url);
+    const highlights = createHighlight('g_remote_prop', 'sample paragraph');
+
+    // Simulate another device adding a highlight
+    await background.evaluate(async ({ url, syncKey, highlights }) => {
+      const now = new Date().toISOString();
+
+      // Update sync_meta first so when the highlight key change arrives, the meta is already consistent if needed
+      const result = await chrome.storage.sync.get('sync_meta');
+      const meta = result.sync_meta || { pages: [], totalSize: 0, deletedUrls: {} };
+      meta.pages.push({ syncKey, url, lastUpdated: now, size: 200 });
+      meta.totalSize += 200;
+      await chrome.storage.sync.set({ sync_meta: meta });
+
+      await chrome.storage.sync.set({
+        [syncKey]: {
+          url,
+          title: 'test-page',
+          lastUpdated: now,
+          highlights,
+          deletedGroupIds: {}
+        }
+      });
+    }, { url, syncKey, highlights });
+
+    // Verify UI update - wait for the propagation
+    const highlightedSpan = page.locator('span.text-highlighter-extension:has-text("sample paragraph")');
+    await expect(highlightedSpan).toBeVisible({ timeout: 10000 });
+
+    // Verify local storage update
+    const local = await background.evaluate(async (url) => {
+      return await chrome.storage.local.get(url);
+    }, url);
+    expect(local[url]).toHaveLength(1);
+    expect(local[url][0].text).toBe('sample paragraph');
+  });
+
+  test('M-11: Live update on deletion from sync', async ({ page, background }) => {
+    const url = `file://${path.join(__dirname, 'test-page.html')}`;
+    const syncKey = urlToSyncKey(url);
+    const highlights = createHighlight('g_to_be_deleted', 'Another paragraph');
+
+    // Setup: already has a highlight in storage BEFORE navigating
+    await background.evaluate(async ({ url, syncKey, highlights }) => {
+      const now = new Date().toISOString();
+      await chrome.storage.local.set({
+        [url]: highlights,
+        [`${url}_meta`]: { title: 'test-page', lastUpdated: now, deletedGroupIds: {} }
+      });
+      await chrome.storage.sync.set({
+        [syncKey]: {
+          url,
+          title: 'test-page',
+          lastUpdated: now,
+          highlights,
+          deletedGroupIds: {}
+        },
+        sync_meta: {
+          pages: [{ syncKey, url, lastUpdated: now, size: 200 }],
+          totalSize: 200,
+          deletedUrls: {}
+        }
+      });
+    }, { url, syncKey, highlights });
+
+    await page.goto(url);
+
+    // Verify it's there first
+    const highlightedSpan = page.locator('span.text-highlighter-extension:has-text("Another paragraph")');
+    await expect(highlightedSpan).toBeVisible();
+
+    // Simulate another device deleting the page highlights
+    await background.evaluate(async ({ url, syncKey }) => {
+      const now = Date.now();
+      const result = await chrome.storage.sync.get('sync_meta');
+      const meta = result.sync_meta || { pages: [], totalSize: 0, deletedUrls: {} };
+      meta.deletedUrls = meta.deletedUrls || {};
+      meta.deletedUrls[url] = now;
+      await chrome.storage.sync.set({ sync_meta: meta });
+      await chrome.storage.sync.remove(syncKey);
+    }, { url, syncKey });
+
+    // Verify UI update (disappears)
+    await expect(highlightedSpan).toHaveCount(0, { timeout: 10000 });
+
+    // Verify local storage update
+    const local = await background.evaluate(async (url) => {
+      return await chrome.storage.local.get(url);
+    }, url);
+    expect(local[url]).toBeUndefined();
+  });
+
+  test('M-6: Merge of highlights (Addition merge)', async ({ page, background }) => {
+    const url = `file://${path.join(__dirname, 'test-page.html')}`;
+    const syncKey = urlToSyncKey(url);
+    const localHighlights = createHighlight('g_local', 'Welcome to the Test Page');
+    const remoteHighlights = createHighlight('g_remote', 'sample paragraph');
+
+    // 1. Setup local highlights
+    await background.evaluate(async ({ url, localHighlights }) => {
+      await chrome.storage.local.set({
+        [url]: localHighlights,
+        [`${url}_meta`]: { title: 'test-page', lastUpdated: new Date().toISOString(), deletedGroupIds: {} }
+      });
+    }, { url, localHighlights });
+
+    await page.goto(url);
+    await expect(page.locator('span.text-highlighter-extension:has-text("Welcome to the Test Page")')).toBeVisible();
+
+    // 2. Simulate another device adding a different highlight
+    await background.evaluate(async ({ url, syncKey, remoteHighlights }) => {
+      const now = new Date().toISOString();
+      await chrome.storage.sync.set({
+        [syncKey]: {
+          url,
+          title: 'test-page',
+          lastUpdated: now,
+          highlights: remoteHighlights,
+          deletedGroupIds: {}
+        }
+      });
+    }, { url, syncKey, remoteHighlights });
+
+    // 3. Both should be visible (Union)
+    await expect(page.locator('span.text-highlighter-extension:has-text("Welcome to the Test Page")')).toBeVisible();
+    await expect(page.locator('span.text-highlighter-extension:has-text("sample paragraph")')).toBeVisible({ timeout: 10000 });
+
+    // 4. Local storage should have both
+    const local = await background.evaluate(async (url) => {
+      return await chrome.storage.local.get(url);
+    }, url);
+    expect(local[url]).toHaveLength(2);
+  });
+
+  test('M-7: Conflict resolution (Last-Write-Wins)', async ({ page, background }) => {
+    const url = `file://${path.join(__dirname, 'test-page.html')}`;
+    const syncKey = urlToSyncKey(url);
+    const groupId = 'g_conflict';
+    const text = 'Welcome to the Test Page';
+
+    const localHighlight = {
+      groupId,
+      color: '#FF0000', // Red
+      text,
+      updatedAt: 1000,
+      spans: [{ spanId: `${groupId}_0`, text, position: 10 }]
+    };
+
+    const remoteHighlight = {
+      groupId,
+      color: '#0000FF', // Blue
+      text,
+      updatedAt: 2000, // Newer
+      spans: [{ spanId: `${groupId}_0`, text, position: 10 }]
+    };
+
+    // 1. Setup local red highlight
+    await background.evaluate(async ({ url, localHighlight }) => {
+      await chrome.storage.local.set({
+        [url]: [localHighlight],
+        [`${url}_meta`]: { title: 'test-page', lastUpdated: new Date().toISOString(), deletedGroupIds: {} }
+      });
+    }, { url, localHighlight });
+
+    await page.goto(url);
+    const highlightedSpan = page.locator('span.text-highlighter-extension:has-text("Welcome to the Test Page")');
+    await expect(highlightedSpan).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+
+    // 2. Simulate another device updating the SAME highlight with a newer timestamp and different color
+    await background.evaluate(async ({ url, syncKey, remoteHighlight }) => {
+      const now = new Date().toISOString();
+      await chrome.storage.sync.set({
+        [syncKey]: {
+          url,
+          title: 'test-page',
+          lastUpdated: now,
+          highlights: [remoteHighlight],
+          deletedGroupIds: {}
+        }
+      });
+    }, { url, syncKey, remoteHighlight });
+
+    // 3. It should update to Blue (LWW)
+    await expect(highlightedSpan).toHaveCSS('background-color', 'rgb(0, 0, 255)', { timeout: 10000 });
+
+    // 4. Local storage should have blue
+    const local = await background.evaluate(async (url) => {
+      return await chrome.storage.local.get(url);
+    }, url);
+    expect(local[url][0].color).toBe('#0000FF');
+  });
+
+  test('M-8: Settings propagation (Minimap visibility)', async ({ page, background }) => {
+    const url = `file://${path.join(__dirname, 'test-page.html')}`;
+    const highlights = createHighlight('g_minimap', 'sample paragraph');
+    await background.evaluate(async ({ url, highlights }) => {
+      await chrome.storage.local.set({ [url]: highlights });
+    }, { url, highlights });
+
+    await page.goto(url);
+
+    // Initially minimap should be visible (default, and we have highlights)
+    const minimap = page.locator('.text-highlighter-minimap');
+    await expect(minimap).toBeVisible();
+
+    // Simulate another device disabling minimap
+    await background.evaluate(async () => {
+      await chrome.storage.sync.set({
+        settings: {
+          minimapVisible: false,
+          selectionControlsVisible: true,
+          customColors: []
+        }
+      });
+    });
+
+    // It should be hidden
+    await expect(minimap).toBeHidden({ timeout: 10000 });
+  });
+
+  test('M-9: Custom colors propagation', async ({ page, background }) => {
+    await page.goto(`file://${path.join(__dirname, 'test-page.html')}`);
+
+    // Simulate another device adding a custom color
+    const customColor = { id: 'custom_123', nameKey: 'customColor', colorNumber: 1, color: '#123456' };
+    await background.evaluate(async (customColor) => {
+      await chrome.storage.sync.set({
+        settings: {
+          minimapVisible: true,
+          selectionControlsVisible: true,
+          customColors: [customColor]
+        }
+      });
+    }, customColor);
+
+    // Verify local storage update
+    await expect.poll(async () => {
+      const result = await background.evaluate(async () => {
+        return await chrome.storage.local.get('customColors');
+      });
+      return result.customColors;
+    }, { timeout: 10000 }).toContainEqual(customColor);
+  });
+
   test('sync key removal without tombstone -> treated as eviction and local data is kept', async ({ background }) => {
     const url = `file:///${path.join(__dirname, 'test-page2.html')}`;
     const syncKey = urlToSyncKey(url);

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1646,7 +1645,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",


### PR DESCRIPTION
I have added several new E2E tests to `e2e-tests/sync.spec.js` to cover the major synchronization scenarios defined in `arch-docs/sync-requirements.md`. These tests verify that highlights, deletions, settings, and custom colors correctly propagate across devices (simulated via `chrome.storage.sync`) and that conflicts are resolved using the Last-Write-Wins strategy.

New tests added:
- M-2: Propagation of new highlights from sync to local and UI.
- M-11: Live update on deletion from sync (verifying tombstone handling).
- M-6: Merge of highlights (ensuring union of highlights from different devices).
- M-7: Conflict resolution (verifying LWW based on `updatedAt`).
- M-8: Settings propagation (verifying minimap visibility toggle propagation).
- M-9: Custom colors propagation.

All 39 existing and new tests passed successfully.

---
*PR created automatically by Jules for task [8643086854198945426](https://jules.google.com/task/8643086854198945426) started by @cuspymd*