### PR TITLE
Fix bulk-delete sync tombstone regression

### DIFF
--- a/background/message-router.js
+++ b/background/message-router.js
@@ -205,7 +205,6 @@ async function handleGetAllHighlightedPages(_message) {
 async function handleDeleteAllHighlightedPages(_message) {
   const result = await browserAPI.storage.local.get(null);
   const keysToDelete = [];
-  const urlsToDelete = [];
 
   const skipKeys = new Set([
     STORAGE_KEYS.CUSTOM_COLORS,
@@ -218,14 +217,13 @@ async function handleDeleteAllHighlightedPages(_message) {
     if (skipKeys.has(key)) continue;
     if (Array.isArray(result[key]) && result[key].length > 0 && !key.endsWith(STORAGE_KEYS.META_SUFFIX)) {
       keysToDelete.push(key, `${key}${STORAGE_KEYS.META_SUFFIX}`);
-      urlsToDelete.push(key);
     }
   }
 
   if (keysToDelete.length > 0) {
     await browserAPI.storage.local.remove(keysToDelete);
     debugLog('All highlighted pages deleted:', keysToDelete);
-    await clearAllSyncedHighlights(urlsToDelete);
+    await clearAllSyncedHighlights();
   }
 
   return successResponse({ deletedCount: keysToDelete.length / 2 });

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -221,9 +221,11 @@ async function applyUserDeletionFromSync(url) {
 }
 
 /**
- * Clear all synced highlights and mark all URLs as user-deleted.
+ * Clear all synced highlights and mark synced URLs as user-deleted.
+ * Tombstones are written only for URLs currently tracked in sync_meta.pages
+ * to keep the sync_meta item within per-item quota.
  */
-export async function clearAllSyncedHighlights(urlsToDelete = []) {
+export async function clearAllSyncedHighlights() {
   try {
     const meta = await getSyncMeta();
     const syncKeysToRemove = meta.pages.map(p => p.syncKey);
@@ -231,9 +233,6 @@ export async function clearAllSyncedHighlights(urlsToDelete = []) {
     const now = Date.now();
     for (const page of meta.pages) {
       if (page.url) meta.deletedUrls[page.url] = now;
-    }
-    for (const url of urlsToDelete) {
-      meta.deletedUrls[url] = now;
     }
 
     await browserAPI.storage.sync.set({ [SYNC_META_KEY]: meta });


### PR DESCRIPTION
## Summary
- restrict bulk-delete tombstones to URLs tracked in sync metadata
- remove unused urlsToDelete plumbing from delete-all flow
- add regression test for clearAllSyncedHighlights behavior
- fix #33 

## Why
Bulk delete previously recorded tombstones for all local URLs, including unsynced pages, which could bloat sync_meta and fail the first sync set before remote highlight keys were removed.

## Test
- npm test -- --runInBand --testPathPattern=sync-service