### PR TITLE
Refactor controls.js to use createHighlightWithColor helper

### DIFF
--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -1104,34 +1104,9 @@ function showSelectionControls(mouseX, mouseY) {
     // Add new event listener for creating highlights
     newColorButton.addEventListener('click', function(e) {
       e.stopPropagation();
-      // Create highlight with selected color
-      if (currentSelection && (currentSelection.range || currentSelection.selection)) {
-        // Restore the selection using the stored range
-        const selection = window.getSelection();
-        selection.removeAllRanges();
-        
-        try {
-          if (currentSelection.range) {
-            selection.addRange(currentSelection.range);
-          } else if (currentSelection.selection.getRangeAt) {
-            selection.addRange(currentSelection.selection.getRangeAt(0));
-          }
-          
-          // Get the color from the button's background color
-          const colorInfo = currentColors[idx];
-          if (colorInfo) {
-            highlightSelectionViaApi(colorInfo.color);
-          }
-          
-          hideSelectionControls();
-          hideSelectionIcon();
-          currentSelection = null;
-        } catch (error) {
-          debugLog('Could not restore selection:', error);
-          hideSelectionControls();
-          hideSelectionIcon();
-          currentSelection = null;
-        }
+      const colorInfo = currentColors[idx];
+      if (colorInfo) {
+        createHighlightWithColor(colorInfo.color);
       }
     });
   });
@@ -1176,7 +1151,7 @@ function setSelectionControlsVisibility(visible) {
 }
 
 
-// Helper function to create highlight with selected color from color picker
+// Helper function to create highlight with selected color
 function createHighlightWithColor(color) {
   if (currentSelection && (currentSelection.range || currentSelection.selection)) {
     // Restore the selection using the stored range

--- a/e2e-tests/selection-controls.spec.js
+++ b/e2e-tests/selection-controls.spec.js
@@ -1,0 +1,48 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, expectHighlightSpan, selectTextInElement } from './fixtures';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test.describe('Selection Controls Tests', () => {
+  test('Should highlight text using the selection control icon', async ({ page }) => {
+    await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+
+    const paragraph = page.locator('p:has-text("This is a sample paragraph")');
+    const textToSelect = "sample paragraph";
+
+    // 1. Select the text
+    await selectTextInElement(paragraph, textToSelect);
+
+    // Simulate mouseup to trigger the icon
+    const box = await paragraph.boundingBox();
+    // We need to pass clientX/clientY for the icon positioning logic
+    await paragraph.dispatchEvent('mouseup', {
+      clientX: box.x + 50,
+      clientY: box.y + 10,
+      bubbles: true
+    });
+
+    // 2. Wait for the selection icon to appear
+    const selectionIcon = page.locator('.text-highlighter-selection-icon');
+    await expect(selectionIcon).toBeVisible();
+
+    // 3. Click the selection icon
+    await selectionIcon.click();
+
+    // 4. Wait for the selection controls to appear
+    const selectionControls = page.locator('.text-highlighter-selection-controls');
+    await expect(selectionControls).toBeVisible();
+
+    // 5. Click the yellow color button (first button)
+    const yellowButton = selectionControls.locator('.text-highlighter-control-button.color-button').nth(0);
+    await yellowButton.click();
+
+    // 6. Verify that the text is highlighted
+    const highlightedSpan = page.locator(`span.text-highlighter-extension:has-text("${textToSelect}")`);
+    await expectHighlightSpan(highlightedSpan, { color: 'rgb(255, 255, 0)', text: textToSelect });
+
+    // 7. Verify controls disappear
+    await expect(selectionControls).toBeHidden();
+    await expect(selectionIcon).toBeHidden();
+  });
+});


### PR DESCRIPTION
- Replaced duplicated highlight creation logic in `showSelectionControls` with `createHighlightWithColor`.
- Updated `createHighlightWithColor` comment to be more generic.
- Added `e2e-tests/selection-controls.spec.js` to verify the functionality.

---
*PR created automatically by Jules for task [3326959676075908050](https://jules.google.com/task/3326959676075908050) started by @cuspymd*