### PR TITLE
🧹 Code Health: Remove unused findTextNodeByContent function

### DIFF
--- a/content-scripts/content.js
+++ b/content-scripts/content.js
@@ -414,25 +414,6 @@ function addHighlightEventListeners(highlightElement) {
   });
 }
 
-// Find text node by content
-function findTextNodeByContent(element, text) {
-  const walker = document.createTreeWalker(
-    element,
-    NodeFilter.SHOW_TEXT,
-    null,
-    false
-  );
-
-  let node;
-  while ((node = walker.nextNode())) {
-    if (node.textContent.includes(text)) {
-      return node;
-    }
-  }
-
-  return null;
-}
-
 // Get position of the first text node in highlight element
 function getFirstTextNodePosition(element) {
   let firstTextNode = null;


### PR DESCRIPTION
Removed the unused `findTextNodeByContent` function from `content-scripts/content.js`. This function was identified as dead code and its removal cleans up the codebase without affecting functionality. Verified by running the test suite and confirming no regressions.

---
*PR created automatically by Jules for task [16320993480753006653](https://jules.google.com/task/16320993480753006653) started by @cuspymd*