### PR TITLE
fix: prevent ghost click on color buttons when selection controls appear on Firefox Mobile

### DIFF
--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -1098,11 +1098,13 @@ function showSelectionControls(mouseX, mouseY) {
   // pointerdown coordinates even after preventDefault(), hitting color buttons that
   // now occupy the same position as the former selection icon. Ignore clicks for
   // 300 ms after the controls appear.
-  selectionControlsContainer.dataset.justShown = 'true';
+  // Capture the current container instance so the timer always clears the flag
+  // on this specific container, not whatever selectionControlsContainer points
+  // to when the timeout fires (which may be a newer instance).
+  const thisContainer = selectionControlsContainer;
+  thisContainer.dataset.justShown = 'true';
   setTimeout(() => {
-    if (selectionControlsContainer) {
-      delete selectionControlsContainer.dataset.justShown;
-    }
+    delete thisContainer.dataset.justShown;
   }, 300);
 
   // Update event listeners for color buttons to create highlights instead of changing existing ones
@@ -1115,7 +1117,7 @@ function showSelectionControls(mouseX, mouseY) {
     // Add new event listener for creating highlights
     newColorButton.addEventListener('click', function(e) {
       e.stopPropagation();
-      if (selectionControlsContainer && selectionControlsContainer.dataset.justShown) {
+      if (thisContainer.dataset.justShown) {
         return;
       }
       const colorInfo = currentColors[idx];


### PR DESCRIPTION
Closes #52

## Root Cause

Commit `634bbb7` changed the selection icon's event handler from `click` to `pointerdown` (to prevent the text selection from collapsing before the controls are shown) and increased the mobile icon hit area to 48×48px.

This introduced a ghost click issue:

1. User taps the pencil icon → `pointerdown` fires on the icon
2. `showSelectionControls(e.clientX, e.clientY)` is called immediately with the tap coordinates
3. The controls are positioned with `topPosition = tapY - 20`. Since the controls are ~44px tall, they span `tapY - 20` to `tapY + 24` — the **tap position itself falls inside the controls bounds**
4. The selection icon is removed from the DOM (`hideSelectionIcon()`)
5. The user lifts their finger → Firefox Mobile dispatches a synthetic `click` at the tap coordinates
6. Even though `preventDefault()` was called on `pointerdown`, Firefox Mobile still fires the click on the element now at those coordinates — a **color button** in the selection controls
7. The color button's click handler calls `createHighlightWithColor()` → highlight is created without the user choosing a color

## Fix

Set a `justShown` data attribute on the `selectionControlsContainer` when the controls first appear, and clear it after 300 ms via `setTimeout`. Each color button click handler checks for this flag and returns early if it is present.

- The ghost click fires within ~50–100 ms of `pointerdown` and is silently discarded
- A deliberate color selection (the user sees the controls and taps a color) takes longer than 300 ms and works normally

```js
// Guard against ghost clicks
selectionControlsContainer.dataset.justShown = 'true';
setTimeout(() => {
  if (selectionControlsContainer) {
    delete selectionControlsContainer.dataset.justShown;
  }
}, 300);

// In each color button click handler
if (selectionControlsContainer && selectionControlsContainer.dataset.justShown) {
  return;
}
```

## Test Plan

- [ ] On Firefox for Android, select text → tap the pencil icon → verify that the selection controls appear and **no highlight is created automatically**
- [ ] Tap a color button in the selection controls → verify a highlight is created with the selected color
- [ ] Verify the same flow works on desktop (mouse) without regression