### PR TITLE
🧹 Refactor Theme Watcher Logic into Shared Utility

### DIFF
--- a/pages-list.js
+++ b/pages-list.js
@@ -2,23 +2,7 @@ import { browserAPI } from './shared/browser-api.js';
 import { debugLog } from './shared/logger.js';
 import { validateImportPayload } from './shared/import-export-schema.js';
 import { createLocalizedModalHelpers } from './shared/modal.js';
-
-// Theme change detection and handling
-function initializeThemeWatcher() {
-  const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-
-  // Initial theme application
-  updateTheme(darkModeQuery.matches);
-
-  // Detect theme change
-  darkModeQuery.addEventListener('change', (e) => {
-    updateTheme(e.matches);
-  });
-}
-
-function updateTheme(isDark) {
-  document.body.setAttribute('data-theme', isDark ? 'dark' : 'light');
-}
+import { initializeThemeWatcher } from './shared/theme.js';
 
 document.addEventListener('DOMContentLoaded', function () {
   // Initialize theme watcher

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 import { browserAPI } from './shared/browser-api.js';
 import { debugLog } from './shared/logger.js';
 import { createLocalizedModalHelpers } from './shared/modal.js';
+import { initializeThemeWatcher } from './shared/theme.js';
 
 const URL_PARAMS  = new URLSearchParams(window.location.search);
 
@@ -53,23 +54,6 @@ function initializeI18n() {
       element.title = message;
     }
   });
-}
-
-// Theme change detection and handling
-function initializeThemeWatcher() {
-  const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  
-  // Initial theme application
-  updateTheme(darkModeQuery.matches);
-  
-  // Detect theme change
-  darkModeQuery.addEventListener('change', (e) => {
-    updateTheme(e.matches);
-  });
-}
-
-function updateTheme(isDark) {
-  document.body.setAttribute('data-theme', isDark ? 'dark' : 'light');
 }
 
 const { showConfirmModal, showAlertModal } = createLocalizedModalHelpers(

--- a/shared/theme.js
+++ b/shared/theme.js
@@ -1,0 +1,16 @@
+// Theme change detection and handling
+export function initializeThemeWatcher() {
+  const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+  // Initial theme application
+  updateTheme(darkModeQuery.matches);
+
+  // Detect theme change
+  darkModeQuery.addEventListener('change', (e) => {
+    updateTheme(e.matches);
+  });
+}
+
+function updateTheme(isDark) {
+  document.body.setAttribute('data-theme', isDark ? 'dark' : 'light');
+}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted duplicated `initializeThemeWatcher` and `updateTheme` logic from `pages-list.js` and `popup.js` into a new `shared/theme.js` utility file.

💡 **Why:** How this improves maintainability
Consolidating this logic into a single source of truth removes redundancy (~15 lines of duplicated code), making theme-related updates or bug fixes easier and less error-prone in the future.

✅ **Verification:** How you confirmed the change is safe
- Verified both files successfully imported and called the new shared function.
- Served the HTML via a local HTTP server and verified using Playwright that `document.body.getAttribute('data-theme')` correctly returned `dark` on both `pages-list.html` and `popup.html`.
- Captured screenshots during the Playwright test and visually confirmed the dark mode appearance.
- Executed the existing Jest test suite (`npm test`), all 92 tests passed.
- Requested and received approval from the code review tool.

✨ **Result:** The improvement achieved
A cleaner, DRY codebase with a dedicated file for theme logic.

---
*PR created automatically by Jules for task [16303842152455415781](https://jules.google.com/task/16303842152455415781) started by @cuspymd*