### PR TITLE
Fix mobile selection controls closing after selection-icon tap

### DIFF
--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -1020,6 +1020,7 @@ function hideSelectionIcon() {
 // Show selection controls (reusing existing controls.js UI without delete button)
 function showSelectionControls(mouseX, mouseY) {
   if (!currentSelection) return;
+  const iconRect = selectionIcon ? selectionIcon.getBoundingClientRect() : null;
   
   hideSelectionControls(); // Remove any existing controls
   
@@ -1088,6 +1089,19 @@ function showSelectionControls(mouseX, mouseY) {
     }
   }
   
+  // Ensure controls cover the icon center point so follow-up click
+  // at icon coordinates lands inside controls.
+  if (iconRect) {
+    const iconCenterX = iconRect.left + iconRect.width / 2;
+    const iconCenterY = iconRect.top + iconRect.height / 2;
+    const minLeft = 0;
+    const minTop = 0;
+    const maxLeft = Math.max(0, viewportWidth - controlsRect.width);
+    const maxTop = Math.max(0, viewportHeight - controlsRect.height);
+    leftPosition = Math.min(Math.max(iconCenterX - controlsRect.width / 2, minLeft), maxLeft);
+    topPosition = Math.min(Math.max(iconCenterY - controlsRect.height / 2, minTop), maxTop);
+  }
+
   // Set final position and make visible
   selectionControlsContainer.style.left = `${leftPosition}px`;
   selectionControlsContainer.style.top = `${topPosition}px`;

--- a/e2e-tests/mobile-selection-controls.spec.js
+++ b/e2e-tests/mobile-selection-controls.spec.js
@@ -1,0 +1,133 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, selectTextInElement } from './fixtures';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function enableSelectionControls(background) {
+  await background.evaluate(async () => {
+    await new Promise((resolve) => {
+      chrome.storage.local.set({ selectionControlsVisible: true }, resolve);
+    });
+  });
+}
+
+async function showSelectionIconForText(page, textToSelect) {
+  const paragraph = page.locator('p:has-text("This is a sample paragraph")');
+  await selectTextInElement(paragraph, textToSelect);
+
+  const box = await paragraph.boundingBox();
+  await paragraph.dispatchEvent('mouseup', {
+    clientX: box.x + 50,
+    clientY: box.y + 10,
+    bubbles: true
+  });
+
+  const selectionIcon = page.locator('.text-highlighter-selection-icon');
+  await expect(selectionIcon).toBeVisible();
+  return selectionIcon;
+}
+
+async function openSelectionControlsWithTouchPointerDown(selectionIcon) {
+  const iconBox = await selectionIcon.boundingBox();
+  const x = iconBox.x + iconBox.width / 2;
+  const y = iconBox.y + iconBox.height / 2;
+
+  await selectionIcon.evaluate((node, point) => {
+    const pointerDown = new PointerEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      pointerId: 1,
+      pointerType: 'touch',
+      isPrimary: true,
+      clientX: point.x,
+      clientY: point.y
+    });
+    node.dispatchEvent(pointerDown);
+  }, { x, y });
+  return { x, y };
+}
+
+async function openSelectionControlsWithClickOnly(selectionIcon) {
+  const iconBox = await selectionIcon.boundingBox();
+  const x = iconBox.x + iconBox.width / 2;
+  const y = iconBox.y + iconBox.height / 2;
+
+  await selectionIcon.evaluate((node, point) => {
+    node.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: point.x,
+      clientY: point.y
+    }));
+  }, { x, y });
+  return { x, y };
+}
+
+async function isPointInsideSelectionControls(page, point) {
+  return await page.evaluate((coords) => {
+    const controls = document.querySelector('.text-highlighter-selection-controls');
+    if (!controls) return false;
+    const rect = controls.getBoundingClientRect();
+    return coords.x >= rect.left &&
+      coords.x <= rect.right &&
+      coords.y >= rect.top &&
+      coords.y <= rect.bottom;
+  }, point);
+}
+
+test.describe('Mobile Selection Controls Regression', () => {
+  test('Controls should overlap icon point after touch-open', async ({ page, background }) => {
+    await enableSelectionControls(background);
+    await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+    await page.waitForTimeout(200);
+
+    const selectionIcon = await showSelectionIconForText(page, 'sample paragraph');
+    const iconCenter = await openSelectionControlsWithTouchPointerDown(selectionIcon);
+
+    const selectionControls = page.locator('.text-highlighter-selection-controls');
+    await expect(selectionControls).toBeVisible();
+    const isInside = await isPointInsideSelectionControls(page, iconCenter);
+    expect(isInside).toBeTruthy();
+  });
+
+  test('Second outside click should still close selection controls', async ({ page, background }) => {
+    await enableSelectionControls(background);
+    await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+    await page.waitForTimeout(200);
+
+    const selectionIcon = await showSelectionIconForText(page, 'sample paragraph');
+    await openSelectionControlsWithTouchPointerDown(selectionIcon);
+
+    const selectionControls = page.locator('.text-highlighter-selection-controls');
+    await expect(selectionControls).toBeVisible();
+
+    await page.evaluate(() => {
+      document.body.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: 5,
+        clientY: 5
+      }));
+    });
+
+    await expect(selectionControls).toBeHidden();
+  });
+
+  test('Controls should overlap icon point on click fallback open', async ({ page, background }) => {
+    await enableSelectionControls(background);
+    await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+    await page.waitForTimeout(200);
+
+    const selectionIcon = await showSelectionIconForText(page, 'sample paragraph');
+    const iconCenter = await openSelectionControlsWithClickOnly(selectionIcon);
+
+    const selectionControls = page.locator('.text-highlighter-selection-controls');
+    await expect(selectionControls).toBeVisible();
+    const isInside = await isPointInsideSelectionControls(page, iconCenter);
+    expect(isInside).toBeTruthy();
+  });
+});

--- a/e2e-tests/selection-controls.spec.js
+++ b/e2e-tests/selection-controls.spec.js
@@ -3,9 +3,19 @@ import { fileURLToPath } from 'url';
 import { test, expect, expectHighlightSpan, selectTextInElement } from './fixtures';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+async function enableSelectionControls(background) {
+  await background.evaluate(async () => {
+    await new Promise((resolve) => {
+      chrome.storage.local.set({ selectionControlsVisible: true }, resolve);
+    });
+  });
+}
+
 test.describe('Selection Controls Tests', () => {
-  test('Should highlight text using the selection control icon', async ({ page }) => {
+  test('Should highlight text using the selection control icon', async ({ page, background }) => {
+    await enableSelectionControls(background);
     await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+    await page.waitForTimeout(200);
 
     const paragraph = page.locator('p:has-text("This is a sample paragraph")');
     const textToSelect = "sample paragraph";


### PR DESCRIPTION
## Summary
This PR fixes a mobile issue where the selection control UI could close immediately after tapping the selection icon, especially after adjusting selection via native selection handles.

## What changed
- Updated selection control positioning logic to ensure the control UI overlaps the selection icon point when opened.
- Added/updated E2E coverage for mobile selection-control behavior and selection-controls stability.

## Verification
- Ran targeted Playwright tests for selection controls.
- Ran full Playwright suite successfully.

Fixes #62
