### PR TITLE
Fix mobile selection icon reappearing when selection controls are open

### DIFF
--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -871,6 +871,7 @@ function handleSelectionMouseUp(e) {
 // Handle touch end event to detect text selection on mobile
 function handleSelectionTouchEnd(e) {
   if (!selectionControlsEnabled) return;
+  if (selectionControlsContainer) return;
 
   const target = e.target;
   if (target.classList.contains('text-highlighter-extension') ||
@@ -925,6 +926,7 @@ function handleSelectionChange() {
 
 // Show selection icon near mouse position
 function showSelectionIcon(mouseX, mouseY) {
+  if (selectionControlsContainer) return;
   hideSelectionIcon(); // Remove any existing icon
   
   selectionIcon = document.createElement('div');

--- a/e2e-tests/mobile-selection-controls.spec.js
+++ b/e2e-tests/mobile-selection-controls.spec.js
@@ -117,6 +117,26 @@ test.describe('Mobile Selection Controls Regression', () => {
     await expect(selectionControls).toBeHidden();
   });
 
+  test('Should not re-show selection icon on touchend while selection controls are open', async ({ page, background }) => {
+    await enableSelectionControls(background);
+    await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);
+    await page.waitForTimeout(200);
+
+    const selectionIcon = await showSelectionIconForText(page, 'sample paragraph');
+    await openSelectionControlsWithTouchPointerDown(selectionIcon);
+
+    const selectionControls = page.locator('.text-highlighter-selection-controls');
+    await expect(selectionControls).toBeVisible();
+
+    await page.evaluate(() => {
+      document.body.dispatchEvent(new Event('touchend', { bubbles: true, cancelable: true }));
+    });
+
+    await page.waitForTimeout(350);
+    await expect(page.locator('.text-highlighter-selection-icon')).toHaveCount(0);
+    await expect(selectionControls).toBeVisible();
+  });
+
   test('Controls should overlap icon point on click fallback open', async ({ page, background }) => {
     await enableSelectionControls(background);
     await page.goto(`file:///${path.join(__dirname, 'test-page.html')}`);


### PR DESCRIPTION
## Summary
This PR fixes a mobile regression where the selection icon could reappear while the selection controls UI was already visible.

## What Changed
- Added a guard in `handleSelectionTouchEnd` to skip icon handling when selection controls are currently open.
- Added a defensive guard in `showSelectionIcon` to prevent icon creation while selection controls are open.
- Added a mobile E2E regression test to verify the icon does not re-show on `touchend` while controls remain visible.

## Validation
- `npx playwright test e2e-tests/mobile-selection-controls.spec.js`

Fixes #64