### PR TITLE
fix: resolve Firefox manifest min-version warnings

### DIFF
--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -92,7 +92,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "text-highlighter@marks.extension",
-      "strict_min_version": "112.0",
+      "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": [
           "none"
@@ -100,7 +100,7 @@
       }
     },
     "gecko_android": {
-      "strict_min_version": "120.0"
+      "strict_min_version": "142.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- raise browser_specific_settings.gecko.strict_min_version to 140.0
- raise browser_specific_settings.gecko_android.strict_min_version to 142.0
- keep data_collection_permissions and align min versions with its support range

## Why
Firefox add-on registration warns when strict_min_version is lower than the versions that support browser_specific_settings.gecko.data_collection_permissions.

## Testing
- JSON parse check for manifest-firefox.json
