### PR TITLE
Implement settings screen and configurable shortcut→color mapping

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Text Highlighter"
   },
   "extensionDescription": {
@@ -190,5 +191,47 @@
   },
   "sortOldestFirst": {
     "message": "Sort by time (oldest first)"
+  },
+  "settingsTitle": {
+    "message": "Settings"
+  },
+  "settingsIconLabel": {
+    "message": "Open Settings"
+  },
+  "generalSection": {
+    "message": "General"
+  },
+  "customColorsSection": {
+    "message": "Custom Colors"
+  },
+  "shortcutsSection": {
+    "message": "Keyboard Shortcuts"
+  },
+  "addCustomColor": {
+    "message": "+ Add Custom Color"
+  },
+  "editColor": {
+    "message": "Change"
+  },
+  "removeColor": {
+    "message": "Remove"
+  },
+  "noCustomColors": {
+    "message": "No custom colors yet."
+  },
+  "colorAlreadyExists": {
+    "message": "This color already exists."
+  },
+  "shortcutSlot": {
+    "message": "Slot"
+  },
+  "notAssigned": {
+    "message": "(Not assigned)"
+  },
+  "shortcutHint": {
+    "message": "Key combinations can be changed in browser shortcut settings (Chrome: chrome://extensions/shortcuts, Firefox: about:addons)."
+  },
+  "colorChangeWarning": {
+    "message": "Changes do not affect existing highlights."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Resaltador de Texto"
   },
   "extensionDescription": {
@@ -190,5 +191,47 @@
   },
   "sortOldestFirst": {
     "message": "Ordenar por tiempo (más antiguo primero)"
+  },
+  "settingsTitle": {
+    "message": "Configuración"
+  },
+  "settingsIconLabel": {
+    "message": "Abrir configuración"
+  },
+  "generalSection": {
+    "message": "General"
+  },
+  "customColorsSection": {
+    "message": "Colores personalizados"
+  },
+  "shortcutsSection": {
+    "message": "Atajos de teclado"
+  },
+  "addCustomColor": {
+    "message": "+ Añadir color personalizado"
+  },
+  "editColor": {
+    "message": "Cambiar"
+  },
+  "removeColor": {
+    "message": "Eliminar"
+  },
+  "noCustomColors": {
+    "message": "Aún no hay colores personalizados."
+  },
+  "colorAlreadyExists": {
+    "message": "Este color ya existe."
+  },
+  "shortcutSlot": {
+    "message": "Ranura"
+  },
+  "notAssigned": {
+    "message": "(Sin asignar)"
+  },
+  "shortcutHint": {
+    "message": "Las combinaciones de teclas se pueden cambiar en la configuración de atajos del navegador (Chrome: chrome://extensions/shortcuts, Firefox: about:addons)."
+  },
+  "colorChangeWarning": {
+    "message": "Los cambios no afectan a los resaltados existentes."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: テキストハイライター"
   },
   "extensionDescription": {
@@ -190,5 +191,47 @@
   },
   "sortOldestFirst": {
     "message": "時間順ソート（古い順）"
+  },
+  "settingsTitle": {
+    "message": "設定"
+  },
+  "settingsIconLabel": {
+    "message": "設定を開く"
+  },
+  "generalSection": {
+    "message": "一般"
+  },
+  "customColorsSection": {
+    "message": "カスタムカラー"
+  },
+  "shortcutsSection": {
+    "message": "キーボードショートカット"
+  },
+  "addCustomColor": {
+    "message": "+ カスタムカラーを追加"
+  },
+  "editColor": {
+    "message": "変更"
+  },
+  "removeColor": {
+    "message": "削除"
+  },
+  "noCustomColors": {
+    "message": "カスタムカラーはまだありません。"
+  },
+  "colorAlreadyExists": {
+    "message": "この色はすでに追加されています。"
+  },
+  "shortcutSlot": {
+    "message": "スロット"
+  },
+  "notAssigned": {
+    "message": "(未割り当て)"
+  },
+  "shortcutHint": {
+    "message": "キーの組み合わせはブラウザのショートカット設定で変更できます (Chrome: chrome://extensions/shortcuts, Firefox: about:addons)."
+  },
+  "colorChangeWarning": {
+    "message": "変更は既存のハイライトには影響しません。"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 텍스트 하이라이터"
   },
   "extensionDescription": {
@@ -190,5 +191,47 @@
   },
   "sortOldestFirst": {
     "message": "시간순 정렬 (오래된 순)"
+  },
+  "settingsTitle": {
+    "message": "설정"
+  },
+  "settingsIconLabel": {
+    "message": "설정 열기"
+  },
+  "generalSection": {
+    "message": "일반"
+  },
+  "customColorsSection": {
+    "message": "사용자 정의 색상"
+  },
+  "shortcutsSection": {
+    "message": "단축키"
+  },
+  "addCustomColor": {
+    "message": "+ 색상 추가"
+  },
+  "editColor": {
+    "message": "변경"
+  },
+  "removeColor": {
+    "message": "삭제"
+  },
+  "noCustomColors": {
+    "message": "사용자 정의 색상이 없습니다."
+  },
+  "colorAlreadyExists": {
+    "message": "이미 추가된 색상입니다."
+  },
+  "shortcutSlot": {
+    "message": "슬롯"
+  },
+  "notAssigned": {
+    "message": "(미배정)"
+  },
+  "shortcutHint": {
+    "message": "키 조합은 브라우저 단축키 설정에서 변경할 수 있습니다 (Chrome: chrome://extensions/shortcuts, Firefox: about:addons)."
+  },
+  "colorChangeWarning": {
+    "message": "기존 하이라이트에는 영향을 주지 않습니다."
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 文本高亮器"
   },
   "extensionDescription": {
@@ -190,5 +191,47 @@
   },
   "sortOldestFirst": {
     "message": "按时间排序（最旧优先）"
+  },
+  "settingsTitle": {
+    "message": "设置"
+  },
+  "settingsIconLabel": {
+    "message": "打开设置"
+  },
+  "generalSection": {
+    "message": "常规"
+  },
+  "customColorsSection": {
+    "message": "自定义颜色"
+  },
+  "shortcutsSection": {
+    "message": "键盘快捷键"
+  },
+  "addCustomColor": {
+    "message": "+ 添加自定义颜色"
+  },
+  "editColor": {
+    "message": "更改"
+  },
+  "removeColor": {
+    "message": "删除"
+  },
+  "noCustomColors": {
+    "message": "还没有自定义颜色。"
+  },
+  "colorAlreadyExists": {
+    "message": "该颜色已存在。"
+  },
+  "shortcutSlot": {
+    "message": "槽位"
+  },
+  "notAssigned": {
+    "message": "（未分配）"
+  },
+  "shortcutHint": {
+    "message": "按键组合可在浏览器快捷键设置中更改（Chrome: chrome://extensions/shortcuts，Firefox: about:addons）。"
+  },
+  "colorChangeWarning": {
+    "message": "更改不会影响现有高亮。"
   }
 }

--- a/arch-docs/message-routing-matrix.md
+++ b/arch-docs/message-routing-matrix.md
@@ -11,6 +11,10 @@ Source of truth: `background/message-router.js`
 | `getHighlights` | `url` | `highlights` | local storage read | `handleGetHighlights` |
 | `clearCustomColors` | none | `success`, `noCustomColors?`, `error?` | local storage write, context menu update, tab broadcast | `handleClearCustomColors` |
 | `addColor` | `color` | `success`, `colors?`, `error?` | local storage write, context menu update, tab broadcast | `handleAddColor` |
+| `updateCustomColor` | `id`, `color` | `success`, `colors?`, `exists?`, `error?` | local storage write, context menu update, tab broadcast | `handleUpdateCustomColor` |
+| `removeCustomColor` | `id` | `success`, `colors?`, `error?` | local storage write, context menu update, tab broadcast | `handleRemoveCustomColor` |
+| `getShortcutColorMap` | none | `success`, `shortcutColorMap`, `error?` | none | `handleGetShortcutColorMap` |
+| `saveShortcutColorMap` | `shortcutColorMap` | `success`, `error?` | local storage write, context menu update, sync save | `handleSaveShortcutColorMap` |
 | `saveHighlights` | `url`, `highlights` | `success`, `error?` | local storage write/remove, sync write/remove | `handleSaveHighlights` |
 | `deleteHighlight` | `url`, `groupId`, `notifyRefresh?` | `success`, `highlights?`, `error?` | local storage write/remove, sync write/remove, tab broadcast (optional) | `handleDeleteHighlight` |
 | `clearAllHighlights` | `url`, `notifyRefresh?` | `success`, `error?` | local storage remove, sync remove, tab broadcast (optional) | `handleClearAllHighlights` |

--- a/background/context-menu.js
+++ b/background/context-menu.js
@@ -5,6 +5,7 @@ import {
   getCurrentColors,
   getCurrentShortcuts,
   getStoredShortcuts,
+  getShortcutColorMap,
   createOrUpdateContextMenus,
 } from './settings-service.js';
 
@@ -50,8 +51,9 @@ export function initContextMenus() {
       if (activeTab) {
         let targetColor = null;
         if (command.startsWith('highlight_')) {
-          const colorId = command.replace('highlight_', '');
-          targetColor = getCurrentColors().find(c => c.id === colorId)?.color;
+          const colorMap = getShortcutColorMap();
+          const colorId = colorMap[command] ?? null;
+          targetColor = colorId ? getCurrentColors().find(c => c.id === colorId)?.color : null;
         }
 
         if (targetColor) {

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -15,6 +15,10 @@ import {
   getCurrentColors,
   addCustomColor,
   clearCustomColors,
+  updateCustomColor,
+  removeCustomColor,
+  getShortcutColorMap,
+  saveShortcutColorMap,
   broadcastSettingsToTabs,
   createOrUpdateContextMenus,
 } from './settings-service.js';
@@ -88,6 +92,37 @@ async function handleAddColor(message) {
     await broadcastToAllTabs({ action: 'colorsUpdated', colors });
   }
   return successResponse({ colors });
+}
+
+
+async function handleUpdateCustomColor(message) {
+  if (!message.id || !message.color) return errorResponse('Missing id or color');
+  const result = await updateCustomColor(message.id, message.color);
+  if (result.notFound) return errorResponse('Color not found');
+  if (result.exists) return successResponse({ exists: true, colors: result.colors });
+  await createOrUpdateContextMenus();
+  await broadcastToAllTabs({ action: 'colorsUpdated', colors: result.colors });
+  return successResponse({ colors: result.colors });
+}
+
+async function handleRemoveCustomColor(message) {
+  if (!message.id) return errorResponse('Missing id');
+  const result = await removeCustomColor(message.id);
+  if (result.notFound) return errorResponse('Color not found');
+  await createOrUpdateContextMenus();
+  await broadcastToAllTabs({ action: 'colorsUpdated', colors: result.colors });
+  return successResponse({ colors: result.colors });
+}
+
+async function handleGetShortcutColorMap(_message) {
+  return successResponse({ shortcutColorMap: getShortcutColorMap() });
+}
+
+async function handleSaveShortcutColorMap(message) {
+  if (!message.shortcutColorMap) return errorResponse('Missing shortcutColorMap');
+  await saveShortcutColorMap(message.shortcutColorMap);
+  await createOrUpdateContextMenus();
+  return successResponse();
 }
 
 async function handleSaveHighlights(message) {
@@ -174,6 +209,7 @@ async function handleGetAllHighlightedPages(_message) {
     STORAGE_KEYS.SYNC_MIGRATION_DONE,
     STORAGE_KEYS.MINIMAP_VISIBLE,
     STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+    STORAGE_KEYS.SHORTCUT_COLOR_MAP,
   ]);
 
   for (const key in result) {
@@ -211,6 +247,7 @@ async function handleDeleteAllHighlightedPages(_message) {
     STORAGE_KEYS.SYNC_MIGRATION_DONE,
     STORAGE_KEYS.MINIMAP_VISIBLE,
     STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+    STORAGE_KEYS.SHORTCUT_COLOR_MAP,
   ]);
 
   for (const key in result) {
@@ -241,6 +278,10 @@ const ACTION_HANDLERS = {
   getHighlights:             handleGetHighlights,
   clearCustomColors:         handleClearCustomColors,
   addColor:                  handleAddColor,
+  updateCustomColor:         handleUpdateCustomColor,
+  removeCustomColor:         handleRemoveCustomColor,
+  getShortcutColorMap:       handleGetShortcutColorMap,
+  saveShortcutColorMap:      handleSaveShortcutColorMap,
   saveHighlights:            handleSaveHighlights,
   deleteHighlight:           handleDeleteHighlight,
   clearAllHighlights:        handleClearAllHighlights,

--- a/background/settings-service.js
+++ b/background/settings-service.js
@@ -12,9 +12,18 @@ const COLORS = [
   { id: 'orange', nameKey: 'orangeColor', color: '#FFAA55' },
 ];
 
+const DEFAULT_SHORTCUT_COLOR_MAP = {
+  highlight_yellow: 'yellow',
+  highlight_green: 'green',
+  highlight_blue: 'blue',
+  highlight_pink: 'pink',
+  highlight_orange: 'orange',
+};
+
 let currentColors = [...COLORS];
 let platformInfo = { os: 'unknown' };
 let storedShortcuts = {};
+let shortcutColorMap = { ...DEFAULT_SHORTCUT_COLOR_MAP };
 
 function getMessage(key) {
   return browserAPI.i18n.getMessage(key);
@@ -84,8 +93,8 @@ export async function createOrUpdateContextMenus() {
   storedShortcuts = { ...commandShortcuts };
 
   for (const color of currentColors) {
-    const commandName = `highlight_${color.id}`;
-    const shortcutDisplay = commandShortcuts[commandName] || '';
+    const commandName = Object.keys(shortcutColorMap).find(k => shortcutColorMap[k] === color.id) || null;
+    const shortcutDisplay = commandName ? (commandShortcuts[commandName] || '') : '';
     const title = color.colorNumber
       ? `${getMessage(color.nameKey)} ${color.colorNumber}${shortcutDisplay}`
       : `${getMessage(color.nameKey)}${shortcutDisplay}`;
@@ -105,6 +114,22 @@ export async function createOrUpdateContextMenus() {
   }
 
   debugLog('Context menus created with shortcuts:', storedShortcuts);
+}
+
+
+async function loadShortcutColorMap() {
+  const result = await browserAPI.storage.local.get([STORAGE_KEYS.SHORTCUT_COLOR_MAP]);
+  shortcutColorMap = result[STORAGE_KEYS.SHORTCUT_COLOR_MAP] || { ...DEFAULT_SHORTCUT_COLOR_MAP };
+}
+
+export function getShortcutColorMap() {
+  return shortcutColorMap;
+}
+
+export async function saveShortcutColorMap(newMap) {
+  shortcutColorMap = { ...newMap };
+  await browserAPI.storage.local.set({ [STORAGE_KEYS.SHORTCUT_COLOR_MAP]: shortcutColorMap });
+  await saveSettingsToSync();
 }
 
 export async function loadCustomColors() {
@@ -145,6 +170,8 @@ export async function loadCustomColors() {
     if (customColors.length) {
       debugLog('Loaded custom colors:', customColors);
     }
+
+    await loadShortcutColorMap();
   } catch (e) {
     console.error('Error loading custom colors', e);
   }
@@ -186,6 +213,48 @@ export async function addCustomColor(newColorValue) {
  * Clear all custom colors.
  * @returns {{ hadColors: boolean, colors: object[] }}
  */
+export async function updateCustomColor(id, newColorValue) {
+  const stored = await browserAPI.storage.local.get([STORAGE_KEYS.CUSTOM_COLORS]);
+  const customColors = stored.customColors || [];
+
+  const idx = customColors.findIndex(c => c.id === id);
+  if (idx === -1) return { notFound: true, colors: currentColors };
+
+  const duplicate = [...COLORS, ...customColors].some(
+    c => c.color.toLowerCase() === newColorValue.toLowerCase() && c.id !== id
+  );
+  if (duplicate) return { exists: true, colors: currentColors };
+
+  customColors[idx] = { ...customColors[idx], color: newColorValue };
+  await browserAPI.storage.local.set({ customColors });
+
+  const globalIdx = currentColors.findIndex(c => c.id === id);
+  if (globalIdx !== -1) currentColors[globalIdx] = { ...currentColors[globalIdx], color: newColorValue };
+
+  await saveSettingsToSync();
+  return { exists: false, colors: currentColors };
+}
+
+export async function removeCustomColor(id) {
+  const stored = await browserAPI.storage.local.get([STORAGE_KEYS.CUSTOM_COLORS]);
+  let customColors = stored.customColors || [];
+
+  const before = customColors.length;
+  customColors = customColors.filter(c => c.id !== id);
+  if (customColors.length === before) return { notFound: true, colors: currentColors };
+
+  await browserAPI.storage.local.set({ customColors });
+  currentColors = currentColors.filter(c => c.id !== id);
+
+  for (const commandName of Object.keys(shortcutColorMap)) {
+    if (shortcutColorMap[commandName] === id) shortcutColorMap[commandName] = null;
+  }
+  await browserAPI.storage.local.set({ [STORAGE_KEYS.SHORTCUT_COLOR_MAP]: shortcutColorMap });
+
+  await saveSettingsToSync();
+  return { colors: currentColors };
+}
+
 export async function clearCustomColors() {
   const result = await browserAPI.storage.local.get([STORAGE_KEYS.CUSTOM_COLORS]);
   const customColors = result.customColors || [];
@@ -254,6 +323,11 @@ export async function applySettingsFromSync(newSettings) {
   if (newSettings.selectionControlsVisible !== undefined) {
     await browserAPI.storage.local.set({ selectionControlsVisible: newSettings.selectionControlsVisible });
     await broadcastToAllTabs({ action: 'setSelectionControlsVisibility', visible: newSettings.selectionControlsVisible });
+  }
+
+  if (newSettings.shortcutColorMap) {
+    await browserAPI.storage.local.set({ [STORAGE_KEYS.SHORTCUT_COLOR_MAP]: newSettings.shortcutColorMap });
+    shortcutColorMap = newSettings.shortcutColorMap;
   }
 
   return { colorsChanged };

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -99,11 +99,13 @@ export async function saveSettingsToSync() {
     STORAGE_KEYS.CUSTOM_COLORS,
     STORAGE_KEYS.MINIMAP_VISIBLE,
     STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+    STORAGE_KEYS.SHORTCUT_COLOR_MAP,
   ]);
   const settings = {
     customColors: result.customColors || [],
     minimapVisible: result.minimapVisible !== undefined ? result.minimapVisible : true,
     selectionControlsVisible: result.selectionControlsVisible !== undefined ? result.selectionControlsVisible : true,
+    shortcutColorMap: result.shortcutColorMap || null,
   };
   try {
     await browserAPI.storage.sync.set({ [SYNC_SETTINGS_KEY]: settings });
@@ -267,6 +269,7 @@ export async function migrateLocalToSync() {
         STORAGE_KEYS.CUSTOM_COLORS,
         STORAGE_KEYS.MINIMAP_VISIBLE,
         STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+        STORAGE_KEYS.SHORTCUT_COLOR_MAP,
       ]);
 
       const mergedSettings = {
@@ -277,6 +280,7 @@ export async function migrateLocalToSync() {
         selectionControlsVisible: syncSettings.selectionControlsVisible !== undefined
           ? syncSettings.selectionControlsVisible
           : (localResult.selectionControlsVisible !== undefined ? localResult.selectionControlsVisible : true),
+        shortcutColorMap: syncSettings.shortcutColorMap || localResult.shortcutColorMap || null,
       };
 
       if (syncSettings.customColors) {
@@ -308,6 +312,7 @@ export async function migrateLocalToSync() {
         STORAGE_KEYS.SYNC_MIGRATION_DONE,
         STORAGE_KEYS.MINIMAP_VISIBLE,
         STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+        STORAGE_KEYS.SHORTCUT_COLOR_MAP,
         'settings',
       ].includes(k) &&
       !k.endsWith(STORAGE_KEYS.META_SUFFIX) &&

--- a/constants/storage-keys.js
+++ b/constants/storage-keys.js
@@ -2,6 +2,7 @@ export const STORAGE_KEYS = {
   CUSTOM_COLORS: 'customColors',
   MINIMAP_VISIBLE: 'minimapVisible',
   SELECTION_CONTROLS_VISIBLE: 'selectionControlsVisible',
+  SHORTCUT_COLOR_MAP: 'shortcutColorMap',
   SYNC_MIGRATION_DONE: 'syncMigrationDone',
   META_SUFFIX: '_meta',
 };

--- a/popup.html
+++ b/popup.html
@@ -55,7 +55,7 @@
       .popup-header {
         display: flex;
         align-items: center;
-        justify-content: flex-start;
+        justify-content: space-between;
         gap: 8px;
       }
 
@@ -78,6 +78,28 @@
         font-size: 18px;
         font-weight: 600;
         letter-spacing: 0.01em;
+      }
+
+
+
+      .icon-btn {
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--muted);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .icon-btn:hover {
+        color: var(--accent);
+        border-color: var(--border);
+        background: var(--surface-strong);
       }
 
       .description {
@@ -255,71 +277,6 @@
         filter: none;
       }
 
-      .toggle-container {
-        display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        gap: 10px;
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        background: var(--surface-strong);
-        padding: 8px 10px;
-      }
-
-      .toggle-container > label:not(.toggle-switch) {
-        margin: 0;
-        color: var(--text);
-        font-size: 13px;
-        font-weight: 500;
-        line-height: 1.25;
-        flex: 1 1 auto;
-        min-width: 0;
-      }
-
-      .toggle-switch {
-        position: relative;
-        width: 42px;
-        height: 24px;
-        flex: 0 0 42px;
-        align-self: center;
-      }
-
-      .toggle-switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-      }
-
-      .toggle-slider {
-        position: absolute;
-        inset: 0;
-        border-radius: 999px;
-        background: #b8bcc6;
-        transition: all 0.2s ease;
-        cursor: pointer;
-      }
-
-      .toggle-slider::before {
-        content: "";
-        position: absolute;
-        width: 18px;
-        height: 18px;
-        left: 3px;
-        top: 3px;
-        border-radius: 50%;
-        background: #fff;
-        transition: transform 0.2s ease;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
-      }
-
-      .toggle-switch input:checked + .toggle-slider {
-        background: var(--accent);
-      }
-
-      .toggle-switch input:checked + .toggle-slider::before {
-        transform: translateX(18px);
-      }
-
       @media (pointer: coarse) {
         body {
           width: auto;
@@ -331,9 +288,6 @@
           font-size: 15px;
         }
 
-        .toggle-container {
-          min-height: 48px;
-        }
       }
     </style>
   </head>
@@ -344,6 +298,12 @@
           <img class="brand-icon" src="images/icon48.png" alt="" aria-hidden="true" />
           <h1 data-i18n="popupTitle">Text Highlighter</h1>
         </div>
+        <button id="open-settings" class="icon-btn" data-i18n-title="settingsIconLabel" title="Settings" aria-label="Settings">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12" />
+          </svg>
+        </button>
       </header>
 
       <p class="description" data-i18n="popupDescription">Select text on web pages and use the control UI to highlight.</p>
@@ -358,23 +318,6 @@
       <section class="section-card actions">
         <button id="view-all-pages" class="btn btn-primary" data-i18n="viewAllPages">Highlighted Pages List</button>
         <button id="clear-all" class="btn" data-i18n="deleteAllHighlights">Delete All Highlights</button>
-        <button id="delete-custom-colors" class="btn" data-i18n="deleteCustomColors">Delete Custom Colors</button>
-
-        <div class="toggle-container">
-          <label for="minimap-toggle" data-i18n="showMinimap">Show Minimap</label>
-          <label class="toggle-switch">
-            <input type="checkbox" id="minimap-toggle" checked />
-            <span class="toggle-slider"></span>
-          </label>
-        </div>
-
-        <div class="toggle-container">
-          <label for="selection-controls-toggle" data-i18n="showControlsOnSelection">Show Control UI on Text Selection</label>
-          <label class="toggle-switch">
-            <input type="checkbox" id="selection-controls-toggle" checked />
-            <span class="toggle-slider"></span>
-          </label>
-        </div>
       </section>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -56,7 +56,7 @@ function initializeI18n() {
   });
 }
 
-const { showConfirmModal, showAlertModal } = createLocalizedModalHelpers(
+const { showConfirmModal } = createLocalizedModalHelpers(
   (key, defaultValue) => browserAPI.i18n.getMessage(key) || defaultValue
 );
 
@@ -71,9 +71,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   const noHighlights = document.getElementById('no-highlights');
   const clearAllBtn = document.getElementById('clear-all');
   const viewAllPagesBtn = document.getElementById('view-all-pages');
-  const deleteCustomColorsBtn = document.getElementById('delete-custom-colors');
-  const minimapToggle = document.getElementById('minimap-toggle');
-  const selectionControlsToggle = document.getElementById('selection-controls-toggle');
+  const openSettingsBtn = document.getElementById('open-settings');
   // Load highlight information from current active tab
   async function loadHighlights() {
     const tab = await getActiveTab();
@@ -147,54 +145,6 @@ document.addEventListener('DOMContentLoaded', async function () {
     }
   }
 
-  // Load minimap settings
-  async function loadMinimapSetting() {
-    const result = await browserAPI.storage.local.get(['minimapVisible']);
-    // Default value is true (show minimap)
-    const isVisible = result.minimapVisible !== undefined ? result.minimapVisible : true;
-    minimapToggle.checked = isVisible;
-    debugLog('Loaded minimap setting:', isVisible);
-  }
-
-  // Load selection controls setting
-  async function loadSelectionControlsSetting() {
-    // On mobile (no browserAPI.windows), always enable and hide the toggle
-    if (!browserAPI.windows) {
-      selectionControlsToggle.closest('.toggle-container').style.display = 'none';
-      debugLog('Mobile platform: selection controls always enabled, toggle hidden');
-      return;
-    }
-    const result = await browserAPI.storage.local.get(['selectionControlsVisible']);
-    // Default value is true (show controls on selection)
-    const isVisible = result.selectionControlsVisible !== undefined ? result.selectionControlsVisible : true;
-    selectionControlsToggle.checked = isVisible;
-    debugLog('Loaded selection controls setting:', isVisible);
-  }
-
-  // Save minimap settings (background handles immediate local broadcast + sync)
-  minimapToggle.addEventListener('change', async function () {
-    const isVisible = minimapToggle.checked;
-
-    // Save to storage via background
-    await browserAPI.runtime.sendMessage({
-      action: 'saveSettings',
-      minimapVisible: isVisible
-    });
-    debugLog('Minimap visibility saved:', isVisible);
-  });
-
-  // Save selection controls settings (background handles immediate local broadcast + sync)
-  selectionControlsToggle.addEventListener('change', async function () {
-    const isVisible = selectionControlsToggle.checked;
-
-    // Save to storage via background
-    await browserAPI.runtime.sendMessage({
-      action: 'saveSettings',
-      selectionControlsVisible: isVisible
-    });
-    debugLog('Selection controls visibility saved:', isVisible);
-  });
-
   // Delete highlight (group basis)
   async function deleteHighlight(groupId, url) {
     const response = await browserAPI.runtime.sendMessage({
@@ -232,22 +182,19 @@ document.addEventListener('DOMContentLoaded', async function () {
     }
   });
 
-  // Delete all custom colors
-  deleteCustomColorsBtn.addEventListener('click', async function () {
-    debugLog('Deleting all custom colors');
-    const confirmMessage = browserAPI.i18n.getMessage('confirmDeleteCustomColors') || 'Delete all custom colors?';
-    const confirmed = await showConfirmModal(confirmMessage);
-    if (confirmed) {
-      const response = await browserAPI.runtime.sendMessage({ action: 'clearCustomColors' });
-      if (response && response.success) {
-        if (response.noCustomColors) {
-          debugLog('No custom colors to delete');
-          await showAlertModal(browserAPI.i18n.getMessage('noCustomColorsToDelete') || 'No custom colors to delete.');
-        } else {
-          debugLog('All custom colors deleted');
-          await showAlertModal(browserAPI.i18n.getMessage('deletedCustomColors') || 'Custom colors deleted.');
-        }
-      }
+
+  openSettingsBtn.addEventListener('click', () => {
+    const settingsUrl = browserAPI.runtime.getURL('settings.html');
+    if (browserAPI.windows) {
+      browserAPI.windows.create({
+        url: settingsUrl,
+        type: 'popup',
+        width: 440,
+        height: 620,
+      });
+    } else {
+      browserAPI.tabs.create({ url: settingsUrl });
+      window.close();
     }
   });
 
@@ -301,6 +248,4 @@ document.addEventListener('DOMContentLoaded', async function () {
 
   // Initialization
   await loadHighlights();
-  await loadMinimapSetting();
-  await loadSelectionControlsSetting();
 });

--- a/scripts/deploy.cjs
+++ b/scripts/deploy.cjs
@@ -13,6 +13,8 @@ const filesToCopy = [
   'background.js',
   'popup.html',
   'popup.js',
+  'settings.html',
+  'settings.js',
   'styles.css',
   'pages-list.html',
   'pages-list.js',

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="settingsTitle">Settings</title>
+    <link rel="stylesheet" href="shared/modal.css" />
+    <style>
+      :root { --bg:#fff; --surface:#f5f5f7; --surface-strong:#fff; --text:#1b1b1f; --muted:#64646b; --border:#e1e1e6; --accent:#8b5cf6; }
+      @media (prefers-color-scheme: dark) {
+        :root { --bg:#121212; --surface:#1c1c1e; --surface-strong:#222226; --text:#f4f4f5; --muted:#ababba; --border:#36363c; --accent:#a78bfa; }
+      }
+      *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,"Segoe UI",sans-serif;font-size:14px}
+      .settings-shell{padding:14px;display:flex;flex-direction:column;gap:12px;max-width:560px}
+      .section-card{border:1px solid var(--border);border-radius:14px;background:var(--surface);padding:12px}
+      .section-title{margin:0 0 10px;font-size:12px;color:var(--muted);text-transform:uppercase}
+      .toggle-container,.settings-row,.shortcut-row{display:flex;align-items:center;justify-content:space-between;gap:10px;border:1px solid var(--border);border-radius:10px;background:var(--surface-strong);padding:8px 10px;margin-top:8px}
+      .swatch{width:16px;height:16px;border-radius:50%;border:1px solid var(--border)}
+      .btn{border:1px solid var(--border);background:var(--surface-strong);color:var(--text);border-radius:8px;padding:6px 8px;cursor:pointer}
+      .btn-primary{color:var(--accent);border-color:rgba(139,92,246,.45);width:100%;margin-top:10px}
+      .label{display:flex;align-items:center;gap:8px;min-width:0}.hint-text,.empty{color:var(--muted);font-size:12px;margin:8px 0 0}
+      select{border:1px solid var(--border);background:var(--surface-strong);color:var(--text);border-radius:8px;padding:6px}
+      .toggle-switch{position:relative;width:42px;height:24px;flex:0 0 42px}.toggle-switch input{opacity:0;width:0;height:0}
+      .toggle-slider{position:absolute;inset:0;border-radius:999px;background:#b8bcc6;cursor:pointer}.toggle-slider::before{content:"";position:absolute;width:18px;height:18px;left:3px;top:3px;border-radius:50%;background:#fff;transition:transform .2s}
+      .toggle-switch input:checked + .toggle-slider{background:var(--accent)} .toggle-switch input:checked + .toggle-slider::before{transform:translateX(18px)}
+    </style>
+  </head>
+  <body>
+    <div class="settings-shell">
+      <section class="section-card">
+        <h2 class="section-title" data-i18n="generalSection">General</h2>
+        <div class="toggle-container">
+          <label for="minimap-toggle" data-i18n="showMinimap">Show Minimap</label>
+          <label class="toggle-switch"><input type="checkbox" id="minimap-toggle" checked /><span class="toggle-slider"></span></label>
+        </div>
+        <div class="toggle-container" id="selection-controls-row">
+          <label for="selection-controls-toggle" data-i18n="showControlsOnSelection">Show Control UI on Text Selection</label>
+          <label class="toggle-switch"><input type="checkbox" id="selection-controls-toggle" checked /><span class="toggle-slider"></span></label>
+        </div>
+      </section>
+
+      <section class="section-card">
+        <h2 class="section-title" data-i18n="customColorsSection">Custom Colors</h2>
+        <div id="custom-colors-list"></div>
+        <p class="hint-text" data-i18n="colorChangeWarning">Changes do not affect existing highlights.</p>
+        <button id="add-custom-color-btn" class="btn btn-primary" data-i18n="addCustomColor">+ Add Custom Color</button>
+        <input type="color" id="color-picker-hidden" style="display:none" />
+      </section>
+
+      <section class="section-card">
+        <h2 class="section-title" data-i18n="shortcutsSection">Keyboard Shortcuts</h2>
+        <div id="shortcuts-list"></div>
+        <p class="hint-text" data-i18n="shortcutHint"></p>
+      </section>
+    </div>
+    <script type="module" src="settings.js"></script>
+  </body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,208 @@
+import { browserAPI } from './shared/browser-api.js';
+import { initializeThemeWatcher } from './shared/theme.js';
+import { createLocalizedModalHelpers } from './shared/modal.js';
+
+const SLOT_COMMANDS = ['highlight_yellow', 'highlight_green', 'highlight_blue', 'highlight_pink', 'highlight_orange'];
+
+function initializeI18n() {
+  document.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.getAttribute('data-i18n');
+    const message = browserAPI.i18n.getMessage(key);
+    if (!message) return;
+    if (element.tagName === 'TITLE') {
+      element.textContent = message;
+      return;
+    }
+    element.textContent = message;
+  });
+}
+
+const { showAlertModal } = createLocalizedModalHelpers((key, defaultValue) => browserAPI.i18n.getMessage(key) || defaultValue);
+
+function getColorLabel(color) {
+  const base = browserAPI.i18n.getMessage(color.nameKey) || color.id;
+  return color.colorNumber ? `${base} ${color.colorNumber}` : base;
+}
+
+async function loadGeneralSettings() {
+  const minimapToggle = document.getElementById('minimap-toggle');
+  const selectionControlsToggle = document.getElementById('selection-controls-toggle');
+  const selectionControlsRow = document.getElementById('selection-controls-row');
+
+  const result = await browserAPI.storage.local.get(['minimapVisible', 'selectionControlsVisible']);
+  minimapToggle.checked = result.minimapVisible !== undefined ? result.minimapVisible : true;
+
+  if (!browserAPI.windows) {
+    selectionControlsRow.style.display = 'none';
+  } else {
+    selectionControlsToggle.checked = result.selectionControlsVisible !== undefined ? result.selectionControlsVisible : true;
+  }
+
+  minimapToggle.addEventListener('change', async () => {
+    await browserAPI.runtime.sendMessage({ action: 'saveSettings', minimapVisible: minimapToggle.checked });
+  });
+
+  selectionControlsToggle.addEventListener('change', async () => {
+    await browserAPI.runtime.sendMessage({ action: 'saveSettings', selectionControlsVisible: selectionControlsToggle.checked });
+  });
+}
+
+async function fetchAllColors() {
+  const response = await browserAPI.runtime.sendMessage({ action: 'getColors' });
+  return response.colors || [];
+}
+
+async function loadCustomColors() {
+  const allColors = await fetchAllColors();
+  const customColors = allColors.filter((c) => c.id.startsWith('custom_'));
+  renderCustomColorsList(customColors);
+}
+
+function renderCustomColorsList(customColors) {
+  const list = document.getElementById('custom-colors-list');
+  list.innerHTML = '';
+
+  if (customColors.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = browserAPI.i18n.getMessage('noCustomColors');
+    list.appendChild(empty);
+    return;
+  }
+
+  customColors.forEach((colorObj) => {
+    const row = document.createElement('div');
+    row.className = 'settings-row';
+
+    const left = document.createElement('div');
+    left.className = 'label';
+
+    const swatch = document.createElement('span');
+    swatch.className = 'swatch';
+    swatch.style.backgroundColor = colorObj.color;
+
+    const text = document.createElement('span');
+    text.textContent = `${getColorLabel(colorObj)} ${colorObj.color}`;
+
+    left.append(swatch, text);
+
+    const actions = document.createElement('div');
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'btn';
+    editBtn.textContent = browserAPI.i18n.getMessage('editColor');
+    editBtn.addEventListener('click', () => handleUpdateColor(colorObj));
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'btn';
+    removeBtn.textContent = browserAPI.i18n.getMessage('removeColor');
+    removeBtn.addEventListener('click', () => handleRemoveColor(colorObj));
+
+    actions.append(editBtn, removeBtn);
+    row.append(left, actions);
+    list.appendChild(row);
+  });
+}
+
+function openColorPicker(initialValue, onChange) {
+  const picker = document.getElementById('color-picker-hidden');
+  picker.value = initialValue;
+  picker.onchange = async () => {
+    await onChange(picker.value);
+    picker.onchange = null;
+  };
+  picker.click();
+}
+
+async function handleUpdateColor(colorObj) {
+  openColorPicker(colorObj.color, async (value) => {
+    const response = await browserAPI.runtime.sendMessage({ action: 'updateCustomColor', id: colorObj.id, color: value });
+    if (response.success) {
+      await loadCustomColors();
+      await loadShortcuts();
+    } else if (response.exists) {
+      await showAlertModal(browserAPI.i18n.getMessage('colorAlreadyExists'));
+    }
+  });
+}
+
+async function handleRemoveColor(colorObj) {
+  const response = await browserAPI.runtime.sendMessage({ action: 'removeCustomColor', id: colorObj.id });
+  if (response.success) {
+    await loadCustomColors();
+    await loadShortcuts();
+  }
+}
+
+function bindAddCustomColor() {
+  document.getElementById('add-custom-color-btn').addEventListener('click', () => {
+    openColorPicker('#ff0000', async (value) => {
+      const response = await browserAPI.runtime.sendMessage({ action: 'addColor', color: value });
+      if (response.success && !response.exists) {
+        await loadCustomColors();
+        await loadShortcuts();
+      } else if (response.exists) {
+        await showAlertModal(browserAPI.i18n.getMessage('colorAlreadyExists'));
+      }
+    });
+  });
+}
+
+async function loadShortcuts() {
+  const [commands, mapResponse, colorsResponse] = await Promise.all([
+    browserAPI.commands ? browserAPI.commands.getAll() : Promise.resolve([]),
+    browserAPI.runtime.sendMessage({ action: 'getShortcutColorMap' }),
+    browserAPI.runtime.sendMessage({ action: 'getColors' }),
+  ]);
+
+  renderShortcutsList(commands, mapResponse.shortcutColorMap || {}, colorsResponse.colors || []);
+}
+
+function renderShortcutsList(commands, colorMap, allColors) {
+  const list = document.getElementById('shortcuts-list');
+  list.innerHTML = '';
+
+  SLOT_COMMANDS.forEach((cmdName, idx) => {
+    const cmd = commands.find((c) => c.name === cmdName);
+    const shortcutLabel = cmd?.shortcut || browserAPI.i18n.getMessage('notAssigned');
+    const assignedColorId = colorMap[cmdName] ?? '';
+
+    const row = document.createElement('div');
+    row.className = 'shortcut-row';
+
+    const label = document.createElement('span');
+    label.textContent = `${browserAPI.i18n.getMessage('shortcutSlot')} ${idx + 1} · ${shortcutLabel}`;
+
+    const select = document.createElement('select');
+    const none = document.createElement('option');
+    none.value = '';
+    none.textContent = browserAPI.i18n.getMessage('notAssigned');
+    select.appendChild(none);
+
+    allColors.forEach((color) => {
+      const option = document.createElement('option');
+      option.value = color.id;
+      option.textContent = getColorLabel(color);
+      if (color.id === assignedColorId) option.selected = true;
+      select.appendChild(option);
+    });
+
+    select.addEventListener('change', async () => {
+      const updatedMap = { ...colorMap, [cmdName]: select.value || null };
+      const response = await browserAPI.runtime.sendMessage({ action: 'saveShortcutColorMap', shortcutColorMap: updatedMap });
+      if (response.success) colorMap[cmdName] = select.value || null;
+    });
+
+    row.append(label, select);
+    list.appendChild(row);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  initializeI18n();
+  initializeThemeWatcher();
+  await loadGeneralSettings();
+  bindAddCustomColor();
+  await loadCustomColors();
+  await loadShortcuts();
+});


### PR DESCRIPTION
### Motivation
- Move settings out of the popup into a dedicated settings UI so the popup focuses on page highlights and the settings page can host richer controls. 
- Support remapping built-in keyboard shortcut slots to any color (including custom colors) at the app level because browser commands are read-only and cannot be changed programmatically. 
- Persist and sync the new shortcut→color mapping across devices and keep custom color operations (add/update/remove) consistent with existing storage and context-menu behavior. 

### Description
- Add a new settings page UI: `settings.html` and `settings.js` implementing General, Custom Colors and Keyboard Shortcuts sections with add/change/remove custom colors and slot→color mapping UI. 
- Introduce a persistent `SHORTCUT_COLOR_MAP` storage key and implement `DEFAULT_SHORTCUT_COLOR_MAP`, `getShortcutColorMap()`, `loadShortcutColorMap()`, and `saveShortcutColorMap()` in `background/settings-service.js`, and add `updateCustomColor()` and `removeCustomColor()`. 
- Add message handlers for the new actions in `background/message-router.js`: `updateCustomColor`, `removeCustomColor`, `getShortcutColorMap`, and `saveShortcutColorMap` and include the new keys in skip lists where appropriate. 
- Resolve shortcut commands via the app-level mapping: `background/context-menu.js` now looks up the color id via `getShortcutColorMap()` and sends the corresponding color to content scripts. 
- Include `shortcutColorMap` in sync payloads and migration flows in `background/sync-service.js`, add `SHORTCUT_COLOR_MAP` to `constants/storage-keys.js`, update `scripts/deploy.cjs` to copy settings assets, and add i18n keys across `_locales/*/messages.json`. 
- Simplify popup by removing settings-related toggles/buttons, adding a settings gear button to open `settings.html`, and update `popup.js`/`popup.html` accordingly. 
- Update documentation `arch-docs/message-routing-matrix.md` to list new message actions. 

### Testing
- Ran the unit/integration test suite with `npm test` and all tests passed: 10 test suites, 92 tests, all green. 
- Performed a production build with `npm run deploy` which completed and copied `settings.html`/`settings.js` into `dist/` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac56888b44832c8ce12f1c0793ffe1)