### PR TITLE
🧹 Remove unused debugLog variable in content-common.js

### DIFF
--- a/content-scripts/content-common.js
+++ b/content-scripts/content-common.js
@@ -1,7 +1,3 @@
-const DEBUG_MODE = false;
-
-var debugLog = DEBUG_MODE ? console.log.bind(console) : () => {};
-
 // Cross-browser compatibility: use browser API in Firefox, chrome API in Chromium.
 var browserAPI = window.browserAPI || (() => {
   if (typeof browser !== 'undefined') {


### PR DESCRIPTION
🎯 **What:** Removed unused `DEBUG_MODE` and `debugLog` variable declarations from `content-scripts/content-common.js`.
💡 **Why:** `DEBUG_MODE` and `debugLog` were locally declared in the file but weren't used, making them dead code. Removing them improves code readability and maintainability.
✅ **Verification:** Ran the full test suite (`npm test`) to ensure no logic relies on these variables and that 93 unit tests passed without issues. Also reviewed codebase via code review which verified the safety of the removal.
✨ **Result:** Cleaned up dead code and successfully executed the code health improvement task!

---
*PR created automatically by Jules for task [1284963003130463813](https://jules.google.com/task/1284963003130463813) started by @cuspymd*