### PR TITLE
fix: clarify popup delete-all label

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -89,7 +89,7 @@
     "message": "No highlighted text on this page."
   },
   "deleteAllHighlights": {
-    "message": "Delete All Highlights"
+    "message": "Delete All Highlights On Page"
   },
   "viewAllPages": {
     "message": "Highlighted Pages List"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -89,7 +89,7 @@
     "message": "No hay texto resaltado en esta página."
   },
   "deleteAllHighlights": {
-    "message": "Limpiar Todos los Resaltados"
+    "message": "Eliminar todos los resaltados de esta página"
   },
   "viewAllPages": {
     "message": "Lista de Páginas Resaltadas"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -89,7 +89,7 @@
     "message": "このページにはハイライトされたテキストがありません。"
   },
   "deleteAllHighlights": {
-    "message": "すべてのハイライトを削除"
+    "message": "このページのハイライトをすべて削除"
   },
   "viewAllPages": {
     "message": "ハイライトしたページ一覧"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -89,7 +89,7 @@
     "message": "현재 페이지에 하이라이트된 텍스트가 없습니다."
   },
   "deleteAllHighlights": {
-    "message": "모든 하이라이트 지우기"
+    "message": "이 페이지의 모든 하이라이트 삭제"
   },
   "viewAllPages": {
     "message": "하이라이트된 페이지 목록"

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -89,7 +89,7 @@
     "message": "当前页面没有高亮的文本。"
   },
   "deleteAllHighlights": {
-    "message": "清除所有高亮"
+    "message": "删除此页面上的所有高亮"
   },
   "viewAllPages": {
     "message": "已高亮页面列表"

--- a/popup.html
+++ b/popup.html
@@ -256,6 +256,10 @@
         color: var(--text);
         font-size: 14px;
         font-weight: 500;
+        line-height: 1.3;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        text-align: center;
         cursor: pointer;
         transition: all 0.2s ease;
       }


### PR DESCRIPTION
## Summary
- clarify the popup delete-all button label so it explicitly refers to the current page
- update localized `deleteAllHighlights` strings for en/es/ja/ko/zh
- allow popup buttons to wrap long localized labels without clipping

## Verification
- checked popup button rendering for es/ja/ko/zh in desktop popup layout
- checked Android portrait simulation (Pixel 7) for es/ja/ko/zh
- confirmed no horizontal overflow or clipped button text
- Spanish delete-all label wraps to 2 lines as expected, but remains fully visible
