### PR TITLE
Fix mobile highlight controls positioning

### DIFF
--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -772,11 +772,29 @@ function showControlUi(highlightElement, e) {
   activeHighlightElement = highlightElement;
   const controlsHeight = 44;
   const controlsWidth = 320;
+  const highlightControlsVerticalOffset = 52;
+  const highlightControlsSpacing = 8;
   const viewportPadding = 10;
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
-  let topPosition = e.clientY - 40;
   const isPortrait = isMobilePlatform && window.innerWidth < window.innerHeight;
+  const highlightRect = highlightElement && typeof highlightElement.getBoundingClientRect === 'function'
+    ? highlightElement.getBoundingClientRect()
+    : null;
+  let topPosition = e.clientY - highlightControlsVerticalOffset;
+
+  if (isMobilePlatform && highlightRect) {
+    const preferredTop = highlightRect.top - controlsHeight - highlightControlsSpacing;
+    const fallbackTop = highlightRect.bottom + highlightControlsSpacing;
+    const canPlaceAboveHighlight = preferredTop >= viewportPadding;
+    const canPlaceBelowHighlight = fallbackTop + controlsHeight <= viewportHeight - viewportPadding;
+
+    if (canPlaceAboveHighlight) {
+      topPosition = preferredTop;
+    } else if (canPlaceBelowHighlight) {
+      topPosition = fallbackTop;
+    }
+  }
 
   if (topPosition + controlsHeight > viewportHeight - viewportPadding) {
     topPosition = viewportHeight - controlsHeight - viewportPadding;

--- a/tests/controls-content-api.integration.test.js
+++ b/tests/controls-content-api.integration.test.js
@@ -79,4 +79,59 @@ describe('controls -> content API integration', () => {
 
     expect(api.changeHighlightColor).toHaveBeenCalledWith(span, '#ffff00');
   });
+
+  it('positions highlight controls slightly above the click point', () => {
+    const span = document.createElement('span');
+    span.className = 'text-highlighter-extension';
+    span.dataset.groupId = 'g3';
+    span.textContent = 'sample';
+    document.body.appendChild(span);
+
+    window.showControlUi(span, { clientX: 100, clientY: 100 });
+
+    const controls = document.querySelector('.text-highlighter-controls');
+    expect(controls.style.top).toBe('48px');
+  });
+
+  it('anchors mobile highlight controls to the highlight rect instead of the touch point', () => {
+    const span = document.createElement('span');
+    span.className = 'text-highlighter-extension';
+    span.dataset.groupId = 'g4';
+    span.textContent = 'sample';
+    document.body.appendChild(span);
+
+    span.getBoundingClientRect = jest.fn(() => ({
+      top: 120,
+      bottom: 140,
+      left: 40,
+      right: 160,
+      width: 120,
+      height: 20,
+    }));
+
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    const originalSendMessage = global.browser.runtime.sendMessage;
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+    global.browser.runtime.sendMessage = jest.fn((message, callback) => {
+      if (!callback) return;
+      if (message.action === 'getPlatformInfo') {
+        callback({ isMobile: true });
+        return;
+      }
+      callback({});
+    });
+    window.initializeSelectionControls();
+
+    window.showControlUi(span, { clientX: 120, clientY: 700 });
+
+    const controls = document.querySelector('.text-highlighter-controls');
+    expect(controls.style.top).toBe('68px');
+
+    global.browser.runtime.sendMessage = originalSendMessage;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+  });
 });


### PR DESCRIPTION
## Summary
- move mobile highlight control positioning to use the highlight element rect instead of relying only on touch-generated click coordinates
- keep desktop and selection control UI behavior unchanged
- add integration coverage for the desktop offset and the mobile rect-anchored positioning path

## Testing
- npm test -- --runTestsByPath tests/controls-content-api.integration.test.js