### PR TITLE
Fix minimap tooltip style collision on sites with global tooltip CSS

### DIFF
--- a/content-scripts/minimap.js
+++ b/content-scripts/minimap.js
@@ -127,7 +127,9 @@ class MinimapManager {
     marker.dataset.highlightId = highlightElement.dataset.highlightId;
     const snippet = (highlightElement.textContent || '').trim().replace(/\s+/g, ' ');
     const tooltipText = snippet.length > 60 ? `${snippet.slice(0, 57)}...` : snippet;
-    marker.dataset.tooltip = tooltipText || 'Highlight';
+    // Avoid generic `data-tooltip` because some sites attach global tooltip
+    // styles to that attribute and override our minimap preview.
+    marker.dataset.minimapTooltip = tooltipText || 'Highlight';
 
     // Marker click event
     marker.addEventListener('click', (e) => {

--- a/styles.css
+++ b/styles.css
@@ -371,7 +371,7 @@
 
 .text-highlighter-minimap-marker::after {
   all: initial;
-  content: attr(data-tooltip);
+  content: attr(data-minimap-tooltip);
   display: block;
   position: absolute;
   left: -8px;


### PR DESCRIPTION
## Summary
- rename the minimap tooltip data attribute to a minimap-specific name
- update the minimap marker CSS to read from the new attribute
- prevent site CSS like Pico's global  tooltip rules from overriding our hover preview

## Testing
- npm test -- --runInBand