### PR TITLE
Improve pages list search UX

### DIFF
--- a/e2e-tests/pages-list.spec.js
+++ b/e2e-tests/pages-list.spec.js
@@ -222,6 +222,40 @@ test.describe('Pages List UI and Delete All Pages', () => {
     await listPage.close();
   });
 
+  test('search expands filtered page details, highlights matching text, and refresh clears the search input', async ({ context, extensionId }) => {
+    const listPage = await context.newPage();
+    await openPagesList(listPage, extensionId);
+
+    const importBtn = listPage.locator('#import-btn');
+    await expect(importBtn).toBeVisible();
+
+    const jsonPath = path.join(__dirname, 'all-highlights-test.json');
+    await importBtn.click();
+    await listPage.setInputFiles('#import-file', jsonPath);
+    await acceptModalAndGetMessage(listPage);
+
+    const searchInput = listPage.locator('#search-input');
+    await searchInput.fill('sample');
+
+    const pageItems = listPage.locator('.page-item');
+    await expect(pageItems).toHaveCount(1);
+
+    const expandedHighlights = pageItems.first().locator('.page-highlights');
+    await expect(expandedHighlights).toBeVisible();
+
+    const matchedMark = expandedHighlights.locator('.highlight-text mark.search-match');
+    await expect(matchedMark).toContainText('sample');
+
+    const refreshBtn = listPage.locator('#refresh-btn');
+    await refreshBtn.click();
+
+    await expect(searchInput).toHaveValue('');
+    await expect(pageItems).toHaveCount(2);
+    await expect(listPage.locator('.page-highlights:visible')).toHaveCount(0);
+
+    await listPage.close();
+  });
+
   test('Verify that only safe URLs are imported when importing JSON containing unsafe URLs', async ({ context, extensionId }) => {
     const listPage = await context.newPage();
     await openPagesList(listPage, extensionId);

--- a/pages-list.html
+++ b/pages-list.html
@@ -316,6 +316,19 @@
         word-break: break-word;
       }
 
+      .search-match {
+        background: rgba(139, 92, 246, 0.22);
+        color: inherit;
+        border-radius: 4px;
+        padding: 0 2px;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .search-match {
+          background: rgba(167, 139, 250, 0.3);
+        }
+      }
+
       #import-btn svg {
         transform: rotate(180deg);
       }

--- a/pages-list.js
+++ b/pages-list.js
@@ -106,19 +106,110 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  function normalizeSearchTerm(searchTerm) {
+    return (searchTerm || '').trim().toLowerCase();
+  }
+
+  function appendHighlightedText(container, text, searchTerm) {
+    const sourceText = text || '';
+    const normalizedTerm = normalizeSearchTerm(searchTerm);
+
+    if (!normalizedTerm) {
+      container.textContent = sourceText;
+      return;
+    }
+
+    const lowerText = sourceText.toLowerCase();
+    let startIndex = 0;
+    let matchIndex = lowerText.indexOf(normalizedTerm, startIndex);
+
+    if (matchIndex === -1) {
+      container.textContent = sourceText;
+      return;
+    }
+
+    while (matchIndex !== -1) {
+      if (matchIndex > startIndex) {
+        container.appendChild(document.createTextNode(sourceText.slice(startIndex, matchIndex)));
+      }
+
+      const mark = document.createElement('mark');
+      mark.className = 'search-match';
+      mark.textContent = sourceText.slice(matchIndex, matchIndex + normalizedTerm.length);
+      container.appendChild(mark);
+
+      startIndex = matchIndex + normalizedTerm.length;
+      matchIndex = lowerText.indexOf(normalizedTerm, startIndex);
+    }
+
+    if (startIndex < sourceText.length) {
+      container.appendChild(document.createTextNode(sourceText.slice(startIndex)));
+    }
+  }
+
+  function renderPageHighlights(page, highlightsContainer, searchTerm) {
+    highlightsContainer.replaceChildren();
+
+    const sortedHighlights = [...(page.highlights || [])].sort((a, b) => {
+      const posA = a.spans && a.spans[0] ? a.spans[0].position : 0;
+      const posB = b.spans && b.spans[0] ? b.spans[0].position : 0;
+      return posA - posB;
+    });
+
+    if (sortedHighlights.length === 0) {
+      const emptyHighlight = document.createElement('div');
+      emptyHighlight.className = 'highlight-item';
+      const emptyText = document.createElement('span');
+      emptyText.className = 'highlight-text';
+      emptyText.textContent = getMessage('noHighlights', 'No highlighted text on this page.');
+      emptyHighlight.appendChild(emptyText);
+      highlightsContainer.appendChild(emptyHighlight);
+      return;
+    }
+
+    sortedHighlights.forEach(group => {
+      const highlightItem = document.createElement('div');
+      highlightItem.className = 'highlight-item';
+      highlightItem.style.setProperty('--highlight-color', group.color);
+      const span = document.createElement('span');
+      span.className = 'highlight-text';
+      appendHighlightedText(span, group.text, searchTerm);
+      highlightItem.appendChild(span);
+      highlightsContainer.appendChild(highlightItem);
+    });
+  }
+
+  function setPageDetailsExpanded(pageItem, page, expand, searchTerm) {
+    const highlightsContainer = pageItem.querySelector('.page-highlights');
+    const detailsButton = pageItem.querySelector('.btn-details');
+
+    if (!expand) {
+      highlightsContainer.style.display = 'none';
+      detailsButton.textContent = getMessage('showDetails', 'Show Details');
+      return;
+    }
+
+    renderPageHighlights(page, highlightsContainer, searchTerm);
+    highlightsContainer.style.display = 'block';
+    detailsButton.textContent = getMessage('hideDetails', 'Hide');
+  }
+
   // Search functionality
   function filterPages(searchTerm) {
-    if (!searchTerm.trim()) {
+    currentSearchTerm = searchTerm || '';
+
+    const normalizedTerm = normalizeSearchTerm(searchTerm);
+
+    if (!normalizedTerm) {
       filteredPages = [...allPages];
     } else {
-      const term = searchTerm.toLowerCase();
       filteredPages = allPages.filter(page => {
         // Search in page title
-        const titleMatch = (page.title || '').toLowerCase().includes(term);
+        const titleMatch = (page.title || '').toLowerCase().includes(normalizedTerm);
 
         // Search in highlight text
         const highlightMatch = page.highlights && page.highlights.some(group =>
-          group.text && group.text.toLowerCase().includes(term)
+          group.text && group.text.toLowerCase().includes(normalizedTerm)
         );
 
         return titleMatch || highlightMatch;
@@ -205,11 +296,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const titleDiv = document.createElement('div');
         titleDiv.className = 'page-title';
-        titleDiv.textContent = pageTitle;
+        appendHighlightedText(titleDiv, pageTitle, currentSearchTerm);
 
         const urlDiv = document.createElement('div');
         urlDiv.className = 'page-url';
-        urlDiv.textContent = page.url;
+        appendHighlightedText(urlDiv, page.url, currentSearchTerm);
 
         const infoDiv = document.createElement('div');
         infoDiv.className = 'page-info';
@@ -249,47 +340,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
         pagesContainer.appendChild(pageItem);
 
+        const shouldAutoExpand = Boolean(normalizeSearchTerm(currentSearchTerm));
+        if (shouldAutoExpand) {
+          setPageDetailsExpanded(pageItem, page, true, currentSearchTerm);
+        }
+
         // Page details button event
         pageItem.querySelector('.btn-details').addEventListener('click', function () {
           const highlightsContainer = pageItem.querySelector('.page-highlights');
-
-          if (highlightsContainer.style.display === 'block') {
-            highlightsContainer.style.display = 'none';
-            this.textContent = getMessage('showDetails', 'Show Details');
-          } else {
-            // Display highlight data
-            highlightsContainer.innerHTML = '';
-            highlightsContainer.style.display = 'block';
-            this.textContent = getMessage('hideDetails', 'Hide');
-
-            const sortedHighlights = [...(page.highlights || [])].sort((a, b) => {
-              const posA = a.spans && a.spans[0] ? a.spans[0].position : 0;
-              const posB = b.spans && b.spans[0] ? b.spans[0].position : 0;
-              return posA - posB;
-            });
-
-            if (sortedHighlights.length === 0) {
-              const emptyHighlight = document.createElement('div');
-              emptyHighlight.className = 'highlight-item';
-              const emptyText = document.createElement('span');
-              emptyText.className = 'highlight-text';
-              emptyText.textContent = getMessage('noHighlights', 'No highlighted text on this page.');
-              emptyHighlight.appendChild(emptyText);
-              highlightsContainer.appendChild(emptyHighlight);
-              return;
-            }
-
-            sortedHighlights.forEach(group => {
-              const highlightItem = document.createElement('div');
-              highlightItem.className = 'highlight-item';
-              highlightItem.style.setProperty('--highlight-color', group.color);
-              const span = document.createElement('span');
-              span.className = 'highlight-text';
-              span.textContent = group.text;
-              highlightItem.appendChild(span);
-              highlightsContainer.appendChild(highlightItem);
-            });
-          }
+          const isExpanded = highlightsContainer.style.display === 'block';
+          setPageDetailsExpanded(pageItem, page, !isExpanded, currentSearchTerm);
         });
 
         // Open page button event
@@ -360,6 +420,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let allPages = [];
   let filteredPages = [];
   let currentSortMode = 'timeDesc'; // 'timeDesc' or 'timeAsc'
+  let currentSearchTerm = '';
 
   // Import highlights event
   if (importBtn && importFileInput) {
@@ -533,6 +594,10 @@ document.addEventListener('DOMContentLoaded', function () {
   // Connect Refresh button events
   if (refreshBtn) {
     refreshBtn.addEventListener('click', function () {
+      currentSearchTerm = '';
+      if (searchInput) {
+        searchInput.value = '';
+      }
       loadAllHighlightedPages();
     });
   }


### PR DESCRIPTION
## Summary
- improve the Pages List search experience by auto-expanding matching page details
- highlight search term matches in page titles, URLs, and highlight text with a theme-aligned purple accent
- reset the search input when the refresh button reloads the list
- add a Playwright E2E test that covers search expansion, match highlighting, and refresh reset behavior

## Testing
- `npm test`
- `npx playwright test e2e-tests/pages-list.spec.js -g "search expands filtered page details, highlights matching text, and refresh clears the search input"`