### PR TITLE
Improve highlight UI accessibility and search empty state

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Text Highlighter"
   },
   "extensionDescription": {
@@ -238,5 +239,20 @@
   },
   "colorChangeWarning": {
     "message": "Changes do not affect existing highlights."
+  },
+  "noSearchResults": {
+    "message": "No results for \"$1\"."
+  },
+  "clearSearch": {
+    "message": "Clear search"
+  },
+  "highlightWithColor": {
+    "message": "Highlight with $1"
+  },
+  "changeHighlightToColor": {
+    "message": "Change highlight to $1"
+  },
+  "deleteHighlightAria": {
+    "message": "Delete this highlight"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Resaltador de Texto"
   },
   "extensionDescription": {
@@ -238,5 +239,20 @@
   },
   "colorChangeWarning": {
     "message": "Los cambios no afectan a los resaltados existentes."
+  },
+  "noSearchResults": {
+    "message": "No hay resultados para \"$1\"."
+  },
+  "clearSearch": {
+    "message": "Borrar búsqueda"
+  },
+  "highlightWithColor": {
+    "message": "Resaltar con $1"
+  },
+  "changeHighlightToColor": {
+    "message": "Cambiar resaltado a $1"
+  },
+  "deleteHighlightAria": {
+    "message": "Eliminar este resaltado"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: テキストハイライター"
   },
   "extensionDescription": {
@@ -238,5 +239,20 @@
   },
   "colorChangeWarning": {
     "message": "既存のハイライトには影響しません。"
+  },
+  "noSearchResults": {
+    "message": "「$1」の結果はありません。"
+  },
+  "clearSearch": {
+    "message": "検索をクリア"
+  },
+  "highlightWithColor": {
+    "message": "$1でハイライト"
+  },
+  "changeHighlightToColor": {
+    "message": "ハイライトを$1に変更"
+  },
+  "deleteHighlightAria": {
+    "message": "このハイライトを削除"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 텍스트 하이라이터"
   },
   "extensionDescription": {
@@ -238,5 +239,20 @@
   },
   "colorChangeWarning": {
     "message": "기존 하이라이트에는 영향을 주지 않습니다."
+  },
+  "noSearchResults": {
+    "message": "“$1”에 대한 결과가 없습니다."
+  },
+  "clearSearch": {
+    "message": "검색 지우기"
+  },
+  "highlightWithColor": {
+    "message": "$1으로 하이라이트"
+  },
+  "changeHighlightToColor": {
+    "message": "하이라이트를 $1으로 변경"
+  },
+  "deleteHighlightAria": {
+    "message": "이 하이라이트 삭제"
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 文本高亮器"
   },
   "extensionDescription": {
@@ -238,5 +239,20 @@
   },
   "colorChangeWarning": {
     "message": "更改不会影响已有的高亮显示。"
+  },
+  "noSearchResults": {
+    "message": "没有“$1”的结果。"
+  },
+  "clearSearch": {
+    "message": "清除搜索"
+  },
+  "highlightWithColor": {
+    "message": "用$1高亮"
+  },
+  "changeHighlightToColor": {
+    "message": "将高亮改为$1"
+  },
+  "deleteHighlightAria": {
+    "message": "删除此高亮"
   }
 }

--- a/content-scripts/controls.js
+++ b/content-scripts/controls.js
@@ -193,10 +193,12 @@ function createHighlightControls() {
   if (highlightControlsContainer) return;
   highlightControlsContainer = document.createElement('div');
   highlightControlsContainer.className = 'text-highlighter-controls';
-  const deleteButton = document.createElement('div');
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
   deleteButton.className = 'text-highlighter-control-button delete-highlight';
   deleteButton.innerHTML = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><line x1="4" y1="4" x2="12" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="4" x2="4" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/></svg>`;
   deleteButton.title = getMessage('deleteHighlight');
+  deleteButton.setAttribute('aria-label', getMessage('deleteHighlight'));
   deleteButton.addEventListener('click', function (e) {
     if (activeHighlightElement) {
       removeHighlightViaApi(activeHighlightElement);
@@ -228,17 +230,21 @@ function createHighlightControls() {
 
 // create colorButton (reusable function)
 function createColorButton(colorInfo) {
-  const colorButton = document.createElement('div');
+  const colorButton = document.createElement('button');
+  colorButton.type = 'button';
   colorButton.className = 'text-highlighter-control-button color-button';
   colorButton.style.backgroundColor = colorInfo.color;
+  let colorLabel;
   if (colorInfo.customName) {
-    colorButton.title = colorInfo.customName;
+    colorLabel = colorInfo.customName;
   } else if (colorInfo.id && colorInfo.id.startsWith('custom_')) {
     const baseName = getMessage('customColor') || 'Custom Color';
-    colorButton.title = colorInfo.colorNumber ? `${baseName} ${colorInfo.colorNumber}` : baseName;
+    colorLabel = colorInfo.colorNumber ? `${baseName} ${colorInfo.colorNumber}` : baseName;
   } else {
-    colorButton.title = getMessage(colorInfo.nameKey);
+    colorLabel = getMessage(colorInfo.nameKey);
   }
+  colorButton.title = colorLabel;
+  colorButton.setAttribute('aria-label', getMessage('changeHighlightToColor', [colorLabel]) || `Change highlight to ${colorLabel}`);
   colorButton.addEventListener('click', function (e) {
     if (activeHighlightElement) {
       changeHighlightColorViaApi(activeHighlightElement, colorInfo.color);
@@ -265,10 +271,12 @@ function createColorButton(colorInfo) {
 
 // create addColorBtn (reusable function)
 function createAddColorButton() {
-  const addColorBtn = document.createElement('div');
+  const addColorBtn = document.createElement('button');
+  addColorBtn.type = 'button';
   addColorBtn.className = 'text-highlighter-control-button add-color-button';
   addColorBtn.innerHTML = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><line x1="8" y1="3" x2="8" y2="13" stroke="#999" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="8" x2="13" y2="8" stroke="#999" stroke-width="2" stroke-linecap="round"/></svg>`;
   addColorBtn.title = getMessage('addColor') || '+';
+  addColorBtn.setAttribute('aria-label', addColorBtn.title);
 
   // Add custom color picker event
   addColorBtn.addEventListener('click', (e) => {
@@ -1281,6 +1289,9 @@ function showSelectionControls(mouseX, mouseY) {
     // Remove existing event listeners by cloning the node
     const newColorButton = colorButton.cloneNode(true);
     colorButton.parentNode.replaceChild(newColorButton, colorButton);
+
+    const colorLabel = newColorButton.title || '';
+    newColorButton.setAttribute('aria-label', getMessage('highlightWithColor', [colorLabel]) || `Highlight with ${colorLabel}`);
 
     // Add new event listener for creating highlights
     newColorButton.addEventListener('click', function(e) {

--- a/e2e-tests/pages-list.spec.js
+++ b/e2e-tests/pages-list.spec.js
@@ -235,6 +235,19 @@ test.describe('Pages List UI and Delete All Pages', () => {
     await acceptModalAndGetMessage(listPage);
 
     const searchInput = listPage.locator('#search-input');
+    await expect(searchInput).toHaveAttribute('aria-label', /^(Search highlights|하이라이트 검색)$/);
+
+    const sortBtn = listPage.locator('#sort-btn');
+    await sortBtn.click();
+    await expect(sortBtn.locator('svg')).toHaveAttribute('aria-hidden', 'true');
+    await expect(sortBtn.locator('svg')).toHaveAttribute('focusable', 'false');
+
+    await searchInput.fill('no-matching-highlight');
+    const noPages = listPage.locator('#no-pages');
+    await expect(noPages).toBeVisible();
+    await expect(noPages).toHaveAttribute('role', 'status');
+    await expect(noPages).toHaveAttribute('aria-live', 'polite');
+
     await searchInput.fill('sample');
 
     const pageItems = listPage.locator('.page-item');

--- a/e2e-tests/popup.spec.js
+++ b/e2e-tests/popup.spec.js
@@ -105,6 +105,7 @@ test.describe('Popup Tests', () => {
     expect(highlight0.startsWith(h1Text.substring(0, 45))).toBe(true);
 
     const deleteBtn = highlightItems.nth(0).locator('.delete-btn');
+    await expect(highlightItems.nth(0)).toHaveCSS('padding-right', '40px');
     await deleteBtn.click();
     const confirmBtn = popupPage.locator('.modal-confirm');
     await expect(confirmBtn).toBeVisible();

--- a/pages-list.html
+++ b/pages-list.html
@@ -136,6 +136,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        gap: 6px;
         padding: 0;
       }
 
@@ -210,12 +211,15 @@
       }
 
       .page-url {
+        display: inline-flex;
+        max-width: 100%;
         font-size: 12px;
         color: var(--muted);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         margin-bottom: 5px;
+        border-radius: 6px;
       }
 
       .page-info {
@@ -342,6 +346,11 @@
         background: var(--surface);
       }
 
+      .clear-search-btn {
+        margin-top: 12px;
+        min-width: 0;
+      }
+
       @media (max-width: 760px) {
         .page-wrap {
           width: min(100% - 16px, 1120px);
@@ -358,6 +367,11 @@
       }
 
       @media (max-width: 500px) {
+        .action-buttons {
+          width: 100%;
+          flex-wrap: wrap;
+        }
+
         .btn {
           min-width: 0;
           padding: 6px 10px;
@@ -391,20 +405,20 @@
         </div>
 
         <div class="action-buttons">
-          <button id="sort-btn" class="icon-btn" data-i18n-title="sortNewestFirst" title="Sort by time (newest first)">
-            <svg viewBox="0 0 24 24"><path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h6v2H3v-2z"/></svg>
+          <button id="sort-btn" class="icon-btn" data-i18n-title="sortNewestFirst" data-i18n-aria-label="sortNewestFirst" title="Sort by time (newest first)">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h6v2H3v-2z"/></svg>
           </button>
-          <button id="refresh-btn" class="icon-btn btn-refresh" data-i18n-title="refresh" title="Refresh">
-            <svg viewBox="0 0 24 24"><path d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.9 6.8h-2.05A6 6 0 1 1 12 6c1.3 0 2.5.42 3.47 1.15L13 9.6h7V3l-2.35 3.35Z"/></svg>
+          <button id="refresh-btn" class="icon-btn btn-refresh" data-i18n-title="refresh" data-i18n-aria-label="refresh" title="Refresh">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.9 6.8h-2.05A6 6 0 1 1 12 6c1.3 0 2.5.42 3.47 1.15L13 9.6h7V3l-2.35 3.35Z"/></svg>
           </button>
-          <button id="delete-all-btn" class="icon-btn btn-delete-all" data-i18n-title="deleteAllPages" title="Delete All Pages">
-            <svg viewBox="0 0 24 24"><path d="M6 19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7H6v12Zm13-15h-3.5l-1-1h-5l-1 1H5v2h14V4Z"/></svg>
+          <button id="delete-all-btn" class="icon-btn btn-delete-all" data-i18n-title="deleteAllPages" data-i18n-aria-label="deleteAllPages" title="Delete All Pages">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6 19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7H6v12Zm13-15h-3.5l-1-1h-5l-1 1H5v2h14V4Z"/></svg>
           </button>
-          <button id="export-all-btn" class="icon-btn" data-i18n-title="exportAllTooltip" title="Export">
-            <svg viewBox="0 0 24 24"><path d="M12 3 5 10h4v6h6v-6h4l-7-7Zm-7 15h14v3H5v-3Z"/></svg>
+          <button id="export-all-btn" class="icon-btn" data-i18n-title="exportAllTooltip" data-i18n-aria-label="exportAllTooltip" title="Export">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 3 5 10h4v6h6v-6h4l-7-7Zm-7 15h14v3H5v-3Z"/></svg>
           </button>
-          <button id="import-btn" class="icon-btn" data-i18n-title="importHighlightsTooltip" title="Import">
-            <svg viewBox="0 0 24 24"><path d="M5 20h14v-2H5v2Zm7-16L5 11h4v5h6v-5h4L12 4Z"/></svg>
+          <button id="import-btn" class="icon-btn" data-i18n-title="importHighlightsTooltip" data-i18n-aria-label="importHighlightsTooltip" title="Import">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 20h14v-2H5v2Zm7-16L5 11h4v5h6v-5h4L12 4Z"/></svg>
           </button>
         </div>
 

--- a/pages-list.html
+++ b/pages-list.html
@@ -401,7 +401,7 @@
           <svg class="search-icon" viewBox="0 0 24 24" aria-hidden="true">
             <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 14 15.5l.27.28v.79L19 21.5 20.5 20l-5-6Zm-6 0A4.5 4.5 0 1 1 9.5 5a4.5 4.5 0 0 1 0 9Z"/>
           </svg>
-          <input id="search-input" class="search-input" type="text" data-i18n-placeholder="searchPlaceholder" placeholder="Search..." />
+          <input id="search-input" class="search-input" type="text" data-i18n-placeholder="searchPlaceholder" data-i18n-aria-label="searchTooltip" placeholder="Search..." aria-label="Search highlights" />
         </div>
 
         <div class="action-buttons">
@@ -426,7 +426,7 @@
       </div>
 
       <div id="pages-container" class="page-grid">
-        <div id="no-pages" class="no-pages" data-i18n="noPagesFound">No highlighted pages found.</div>
+        <div id="no-pages" class="no-pages" data-i18n="noPagesFound" role="status" aria-live="polite">No highlighted pages found.</div>
       </div>
     </div>
 

--- a/pages-list.js
+++ b/pages-list.js
@@ -85,6 +85,13 @@ document.addEventListener('DOMContentLoaded', function () {
       element.title = getMessage(key, element.title);
     });
 
+    // Handle data-i18n-aria-label attributes
+    const elementsWithAriaLabel = document.querySelectorAll('[data-i18n-aria-label]');
+    elementsWithAriaLabel.forEach(element => {
+      const key = element.getAttribute('data-i18n-aria-label');
+      element.setAttribute('aria-label', getMessage(key, element.getAttribute('aria-label') || element.title || ''));
+    });
+
     // Handle data-i18n-placeholder attributes
     const elementsWithPlaceholder = document.querySelectorAll('[data-i18n-placeholder]');
     elementsWithPlaceholder.forEach(element => {
@@ -108,6 +115,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function normalizeSearchTerm(searchTerm) {
     return (searchTerm || '').trim().toLowerCase();
+  }
+
+  function formatDisplayUrl(urlString) {
+    if (!urlString) return '';
+    try {
+      const url = new URL(urlString);
+      if (url.protocol === 'file:') {
+        const parts = decodeURIComponent(url.pathname).split('/').filter(Boolean);
+        const fileName = parts.pop() || url.pathname;
+        const parent = parts.pop();
+        return parent ? `file://…/${parent}/${fileName}` : `file://…/${fileName}`;
+      }
+      if (url.hostname) {
+        const path = decodeURIComponent(url.pathname || '/');
+        const shortPath = path.length > 48 ? `${path.slice(0, 45)}…` : path;
+        return `${url.hostname}${shortPath}${url.search ? '…' : ''}`;
+      }
+    } catch (e) {
+      // Fall through to length-based truncation.
+    }
+    return urlString.length > 72 ? `${urlString.slice(0, 69)}…` : urlString;
   }
 
   function appendHighlightedText(container, text, searchTerm) {
@@ -300,7 +328,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const urlDiv = document.createElement('div');
         urlDiv.className = 'page-url';
-        appendHighlightedText(urlDiv, page.url, currentSearchTerm);
+        urlDiv.title = page.url;
+        urlDiv.setAttribute('aria-label', page.url);
+        appendHighlightedText(urlDiv, formatDisplayUrl(page.url), currentSearchTerm);
 
         const infoDiv = document.createElement('div');
         infoDiv.className = 'page-info';
@@ -369,6 +399,31 @@ document.addEventListener('DOMContentLoaded', function () {
     } else {
       noPages.style.display = 'block';
       pagesContainer.innerHTML = '';
+      noPages.replaceChildren();
+
+      const normalizedTerm = normalizeSearchTerm(currentSearchTerm);
+      if (normalizedTerm) {
+        const message = document.createElement('div');
+        message.textContent = getMessage('noSearchResults', `No results for "${currentSearchTerm}".`, [currentSearchTerm]);
+        noPages.appendChild(message);
+
+        const clearButton = document.createElement('button');
+        clearButton.type = 'button';
+        clearButton.className = 'btn clear-search-btn';
+        clearButton.textContent = getMessage('clearSearch', 'Clear search');
+        clearButton.addEventListener('click', () => {
+          currentSearchTerm = '';
+          if (searchInput) {
+            searchInput.value = '';
+            searchInput.focus();
+          }
+          filterPages('');
+        });
+        noPages.appendChild(clearButton);
+      } else {
+        noPages.textContent = getMessage('noPagesFound', 'No highlighted pages found.');
+      }
+
       pagesContainer.appendChild(noPages);
     }
   }
@@ -541,12 +596,14 @@ document.addEventListener('DOMContentLoaded', function () {
           <path d="M3 6h6v2H3V6zm0 5h12v2H3v-2zm0 5h18v2H3v-2z"/>
         </svg>`;
         sortBtn.title = getMessage('sortOldestFirst', 'Sort by time (oldest first)');
+        sortBtn.setAttribute('aria-label', sortBtn.title);
         sortBtn.classList.add('sort-active');
       } else {
         sortBtn.innerHTML = `<svg viewBox="0 0 24 24">
           <path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h6v2H3v-2z"/>
         </svg>`;
         sortBtn.title = getMessage('sortNewestFirst', 'Sort by time (newest first)');
+        sortBtn.setAttribute('aria-label', sortBtn.title);
         sortBtn.classList.remove('sort-active');
       }
 

--- a/pages-list.js
+++ b/pages-list.js
@@ -592,14 +592,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Update button appearance and tooltip
       if (currentSortMode === 'timeAsc') {
-        sortBtn.innerHTML = `<svg viewBox="0 0 24 24">
+        sortBtn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
           <path d="M3 6h6v2H3V6zm0 5h12v2H3v-2zm0 5h18v2H3v-2z"/>
         </svg>`;
         sortBtn.title = getMessage('sortOldestFirst', 'Sort by time (oldest first)');
         sortBtn.setAttribute('aria-label', sortBtn.title);
         sortBtn.classList.add('sort-active');
       } else {
-        sortBtn.innerHTML = `<svg viewBox="0 0 24 24">
+        sortBtn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
           <path d="M3 6h18v2H3V6zm0 5h12v2H3v-2zm0 5h6v2H3v-2z"/>
         </svg>`;
         sortBtn.title = getMessage('sortNewestFirst', 'Sort by time (newest first)');

--- a/popup.html
+++ b/popup.html
@@ -210,34 +210,37 @@
         position: absolute;
         right: 8px;
         top: 8px;
-        width: 16px;
-        height: 16px;
-        border-radius: 50%;
-        border: 1px solid var(--border);
+        width: 24px;
+        height: 24px;
+        border-radius: 999px;
+        border: 1px solid rgba(212, 58, 47, 0.35);
         display: grid;
         place-items: center;
-        font-size: 11px;
-        font-weight: 600;
-        line-height: 1;
         padding: 0;
         cursor: pointer;
-        color: var(--muted);
+        color: var(--danger);
         background: var(--surface);
-        opacity: 0.72;
-        transition: opacity 0.18s ease, border-color 0.18s ease, color 0.18s ease, background-color 0.18s ease;
+        opacity: 0.86;
+        transition: opacity 0.18s ease, border-color 0.18s ease, color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
       }
 
       .delete-icon {
-        display: inline-block;
-        line-height: 1;
+        width: 14px;
+        height: 14px;
+        fill: currentColor;
+      }
+
+      .delete-btn:hover,
+      .delete-btn:focus-visible {
+        border-color: var(--danger);
+        background: rgba(212, 58, 47, 0.1);
+        opacity: 1;
         transform: translateY(-1px);
       }
 
-      .delete-btn:hover {
-        border-color: var(--accent);
-        color: var(--accent);
-        background: var(--surface-strong);
-        opacity: 1;
+      .delete-btn:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
       }
 
       .actions {

--- a/popup.html
+++ b/popup.html
@@ -169,7 +169,7 @@
         border-radius: 12px;
         background: var(--surface-strong);
         border: 1px solid var(--border);
-        padding: 8px 28px 8px 12px;
+        padding: 8px 40px 8px 12px;
         padding-left: 14px;
         line-height: 1.35;
         word-break: break-word;

--- a/popup.js
+++ b/popup.js
@@ -116,16 +116,13 @@ document.addEventListener('DOMContentLoaded', async function () {
         textSpan.textContent = displayText;
 
         // Add delete button
-        const deleteBtn = document.createElement('span');
+        const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
         deleteBtn.className = 'delete-btn';
-        const removeLabel = browserAPI.i18n.getMessage('removeHighlight');
+        const removeLabel = browserAPI.i18n.getMessage('deleteHighlightAria') || browserAPI.i18n.getMessage('removeHighlight');
         deleteBtn.title = removeLabel;
         deleteBtn.setAttribute('aria-label', removeLabel);
-
-        const deleteIcon = document.createElement('span');
-        deleteIcon.className = 'delete-icon';
-        deleteIcon.textContent = 'x';
-        deleteBtn.appendChild(deleteIcon);
+        deleteBtn.innerHTML = `<svg class="delete-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6 19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7H6v12Zm13-15h-3.5l-1-1h-5l-1 1H5v2h14V4Z"/></svg>`;
         deleteBtn.addEventListener('click', async function (e) {
           e.stopPropagation();
           const confirmMessage =

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,12 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
+  border: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
   display: flex;
   align-items: center;
   transition: transform 0.18s cubic-bezier(.4,1.4,.6,1), box-shadow 0.18s cubic-bezier(.4,1.4,.6,1);
@@ -104,9 +110,14 @@
   }
 }
 
-.text-highlighter-control-button:hover, .text-highlighter-control-button:focus {
+.text-highlighter-control-button:hover, .text-highlighter-control-button:focus-visible {
   transform: scale(1.18);
   z-index: 1;
+}
+
+.text-highlighter-control-button:focus-visible {
+  outline: 2px solid #8b5cf6;
+  outline-offset: 2px;
 }
 
 .text-highlighter-control-button.jelly-animate {


### PR DESCRIPTION
## Summary
- Convert in-page highlight control color/delete/add chips to semantic buttons with aria labels and focus-visible styling
- Improve popup highlight deletion from a tiny `x` to an accessible trash icon button
- Add aria labels to highlighted-pages toolbar icon buttons while keeping them icon-only
- Distinguish search-empty state from truly empty pages and add a clear-search action
- Shorten long URLs in page cards while preserving the full URL in title/aria-label
- Add localized strings for new accessibility/search messages across supported locales

## Validation
- `npm test -- --runInBand` → 110 passed
- `npx playwright test e2e-tests/selection-controls.spec.js e2e-tests/mobile-selection-controls.spec.js e2e-tests/popup.spec.js e2e-tests/pages-list.spec.js --reporter=line` → 24 passed
- `npx playwright test e2e-tests/pages-list.spec.js --reporter=line` → 9 passed after mobile label revert
- `npm run deploy`
- `npm run deploy:firefox`
