### PR TITLE
Add Cloudflare KV-based cloud sync for Firefox Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ outputs/
 .jest_cache/
 /test-results/
 .claude/
+worker/.wrangler/

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -247,5 +247,59 @@
   },
   "colorChangeWarning": {
     "message": "Changes do not affect existing highlights."
+  },
+  "cloudSyncSection": {
+    "message": "Cloud Sync (Beta)"
+  },
+  "cloudSyncIntro": {
+    "message": "Sync highlights across devices via an encrypted cloud backup, for platforms (like Firefox for Android) where browser sync isn't available. Your data is encrypted on this device before upload; the sync code is the only way to decrypt it."
+  },
+  "cloudSyncGenerateCode": {
+    "message": "Generate New Code"
+  },
+  "cloudSyncPairCodePlaceholder": {
+    "message": "Enter sync code from another device"
+  },
+  "cloudSyncPairCodeButton": {
+    "message": "Connect"
+  },
+  "cloudSyncInvalidCode": {
+    "message": "That sync code doesn't look right. Double-check it and try again."
+  },
+  "cloudSyncYourCode": {
+    "message": "Your Sync Code"
+  },
+  "cloudSyncSaveCodeWarning": {
+    "message": "Save this code somewhere safe. If you lose it, this data cannot be recovered."
+  },
+  "cloudSyncCopyCode": {
+    "message": "Copy"
+  },
+  "cloudSyncCodeCopied": {
+    "message": "Copied!"
+  },
+  "cloudSyncEnabledLabel": {
+    "message": "Cloud Sync"
+  },
+  "cloudSyncNowButton": {
+    "message": "Sync Now"
+  },
+  "cloudSyncSyncing": {
+    "message": "Syncing..."
+  },
+  "cloudSyncNeverSynced": {
+    "message": "Not synced yet"
+  },
+  "cloudSyncLastSyncedPrefix": {
+    "message": "Last synced: "
+  },
+  "cloudSyncErrorPrefix": {
+    "message": "Sync error: "
+  },
+  "cloudSyncResetButton": {
+    "message": "Forget Code"
+  },
+  "cloudSyncResetConfirm": {
+    "message": "This disconnects this device and permanently forgets the sync code. Data already uploaded to the cloud will remain unless you also reset it from another connected device. Continue?"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -247,5 +247,59 @@
   },
   "colorChangeWarning": {
     "message": "기존 하이라이트에는 영향을 주지 않습니다."
+  },
+  "cloudSyncSection": {
+    "message": "클라우드 동기화 (베타)"
+  },
+  "cloudSyncIntro": {
+    "message": "브라우저 자체 동기화를 지원하지 않는 환경(예: Android용 Firefox)을 위해, 암호화된 클라우드 백업으로 기기 간 하이라이트를 동기화합니다. 데이터는 업로드 전에 이 기기에서 암호화되며, 동기화 코드가 있어야만 복호화할 수 있습니다."
+  },
+  "cloudSyncGenerateCode": {
+    "message": "새 코드 생성"
+  },
+  "cloudSyncPairCodePlaceholder": {
+    "message": "다른 기기의 동기화 코드 입력"
+  },
+  "cloudSyncPairCodeButton": {
+    "message": "연결"
+  },
+  "cloudSyncInvalidCode": {
+    "message": "동기화 코드가 올바르지 않습니다. 다시 확인해 주세요."
+  },
+  "cloudSyncYourCode": {
+    "message": "내 동기화 코드"
+  },
+  "cloudSyncSaveCodeWarning": {
+    "message": "이 코드를 안전한 곳에 보관하세요. 분실하면 데이터를 복구할 수 없습니다."
+  },
+  "cloudSyncCopyCode": {
+    "message": "복사"
+  },
+  "cloudSyncCodeCopied": {
+    "message": "복사됨!"
+  },
+  "cloudSyncEnabledLabel": {
+    "message": "클라우드 동기화"
+  },
+  "cloudSyncNowButton": {
+    "message": "지금 동기화"
+  },
+  "cloudSyncSyncing": {
+    "message": "동기화 중..."
+  },
+  "cloudSyncNeverSynced": {
+    "message": "아직 동기화되지 않음"
+  },
+  "cloudSyncLastSyncedPrefix": {
+    "message": "마지막 동기화: "
+  },
+  "cloudSyncErrorPrefix": {
+    "message": "동기화 오류: "
+  },
+  "cloudSyncResetButton": {
+    "message": "코드 초기화"
+  },
+  "cloudSyncResetConfirm": {
+    "message": "이 기기의 연결을 해제하고 동기화 코드를 완전히 잊어버립니다. 이미 클라우드에 업로드된 데이터는 다른 연결된 기기에서 초기화하지 않는 한 그대로 남아 있습니다. 계속할까요?"
   }
 }

--- a/arch-docs/cloudflare-kv-based-sync-design.md
+++ b/arch-docs/cloudflare-kv-based-sync-design.md
@@ -1,0 +1,305 @@
+# Cloudflare KV 기반 클라우드 동기화 설계안
+
+## 배경 및 목표
+
+text-highlighter는 현재 `storage.sync` API로 하이라이트와 설정을 동기화한다(`arch-docs/sync-requirements.md`, `background/sync-service.js`). 그러나 **Firefox Android는 `storage.sync`를 지원하지 않아** 해당 플랫폼에서는 기기 간 동기화가 불가능하다.
+
+이 문서는 브라우저 자체 sync에 의존하지 않고, **Cloudflare 무료 티어만으로** 별도의 클라우드 동기화를 제공하는 방안을 정리한다. 핵심 제약은 다음과 같다.
+
+- Cloudflare **무료 티어**만 사용 (유료 플랜/애드온 없음)
+- 서버는 암호문만 저장 — **클라이언트 사이드 종단간 암호화(E2EE)**로 개인정보 보호
+- 사용자 수가 적은 무료 확장 프로그램이라는 전제하에, **구현 복잡도를 최소화**하는 방향을 우선 (계정 시스템·서버측 인증·rate limiting 등은 1차 범위에서 제외)
+
+관련 논의 경과:
+- Cloudflare KV(무료 쓰기 1,000/일)는 "하이라이트 변경마다 push"하는 현재 패턴엔 부적합하다고 판단했으나, **URL별 개별 동기화 대신 전체 데이터를 하나의 블롭으로 묶어 배치 동기화**하면 쓰기 횟수가 크게 줄어 KV로도 충분하다는 결론에 도달함
+- 확장 프로그램은 "비밀을 가질 수 없는 클라이언트"이므로 별도 API 키로 확장 프로그램 자체를 인증하려 하지 않음. 대신 사용자별 **동기화 코드에서 파생한 고유 키(`keyId`)** 를 리소스 접근 토큰으로 사용
+- 어뷰징 방어(rate limiting 등)는 **1차 구현에서 생략**하고, 실제 문제가 발생하면 그때 대응하기로 함
+
+---
+
+## 1) 왜 KV인가
+
+| 서비스 | 무료 티어 제한 | 비고 |
+|---|---|---|
+| **Workers KV** | 읽기 100k/일, 쓰기 1,000/일(네임스페이스 전체), 값 크기 25MB, 저장 1GB | 유저당 **블롭 1개**로 배치 동기화하면 쓰기 횟수가 적어 채택 가능 |
+| D1 | 읽기 500만 row/일, 쓰기 10만 row/일, 5GB | 스키마/쿼리 설계 필요, 이번 범위엔 과함 |
+| R2 | 저장 10GB, Class A(쓰기) 100만/월, Class B(읽기) 1000만/월 | 쿼리 기능 없음, KV와 목적이 겹침 |
+| Durable Objects | 무료 플랜 미지원 | 제외 |
+
+→ **Workers + KV**, 유저당 KV 항목 1개(`blob:<keyId>`)로 결정. 값 크기 제한(25MB)이 커서 기존 `storage.sync`의 8KB/아이템·90KB 총량 제약과 그로 인한 eviction/예산 로직이 통째로 불필요해진다.
+
+---
+
+## 2) 전체 아키텍처
+
+```
+[기기 A]  content/background  ──┐
+                                 ├─ fetch(GET/PUT) ─→ [Cloudflare Worker] ─→ [KV Namespace]
+[기기 B]  content/background  ──┘                         (blob:<keyId>)
+```
+
+- Worker는 인증 헤더 없이 `GET /blob/:keyId`, `PUT /blob/:keyId`만 제공하는 얇은 프록시
+- 서버는 항상 **암호문**만 다루며 평문 하이라이트나 encryptionKey를 알 수 없음
+- 기기 간 실시간 push는 없음 — pull-merge-push 방식의 주기적/수동 동기화
+
+---
+
+## 3) 동기화 코드(Sync Code) 설계
+
+### 3.1 생성
+
+```js
+function generateSyncCode() {
+  const bytes = crypto.getRandomValues(new Uint8Array(32)); // 256bit
+  return encodeCrockfordBase32Grouped(bytes); // 예: "K7QZ-9X2M-P4R8-7H3D-..."
+}
+```
+
+- 최초로 클라우드 동기화를 켤 때 1회 생성
+- Crockford Base32 + 4자리 그룹 표기로 오타 발생 가능성이 높은 문자(0/O, 1/I) 제외
+- 코드는 사용자에게 표시 + 복사 버튼 제공. **"저장하지 않으면 복구 불가"**를 온보딩 화면에 명시
+
+### 3.2 키 파생 (HKDF)
+
+패스워드가 아닌 완전 난수이므로 PBKDF2 같은 stretching 없이 HKDF만으로 충분하다.
+
+```js
+async function deriveSyncKeys(syncCode) {
+  const codeBytes = decodeCrockfordBase32(syncCode);
+  const baseKey = await crypto.subtle.importKey(
+    'raw', codeBytes, 'HKDF', false, ['deriveKey', 'deriveBits']
+  );
+
+  const encryptionKey = await crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: utf8('th-sync-encrypt-v1') },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+
+  const keyIdBits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: utf8('th-sync-keyid-v1') },
+    baseKey,
+    128
+  );
+
+  return { encryptionKey, keyId: toHex(keyIdBits) };
+}
+```
+
+- `info` 문자열만 다르게 주어 하나의 코드에서 서로 다른 두 값을 결정적으로 파생 (동일 코드 입력 시 모든 기기가 같은 값 도출)
+- `encryptionKey`는 `extractable: false`로 생성해 메모리 덤프 외에는 추출 불가
+- `keyId`는 128bit(hex 32자)로 충분한 엔트로피 확보
+
+### 3.3 다기기 페어링
+
+1. 기기 A: 코드 생성 → 로컬 저장(`browser.storage.local`) → 최초 업로드
+2. 기기 B: 옵션 화면에서 코드 입력 → 동일 연산으로 동일 `keyId`/`encryptionKey` 도출(서버 통신 없이 로컬 계산) → pull-merge-push 1회 수행
+
+### 3.4 코드 분실/변경
+
+- 분실 시 복구 불가 — 새 코드로 새로 시작
+- 로테이션 시 새 `keyId`로 현재 병합 데이터를 재업로드하고, 기존 `keyId` 데이터는 그대로 두거나(TTL로 자연 소멸) 사용자가 명시적으로 `DELETE`
+
+---
+
+## 4) 데이터 모델 (블롭 구조)
+
+기존 로컬 스키마(URL별 하이라이트 + `_meta`)와 `SYNC_KEYS.SETTINGS` 페이로드를 하나의 JSON으로 통합한다.
+
+```json
+{
+  "version": 1,
+  "updatedAt": 1735800000000,
+  "settings": {
+    "customColors": [],
+    "minimapVisible": true,
+    "selectionControlsVisible": true,
+    "shortcutColorMap": null
+  },
+  "pages": {
+    "<url>": {
+      "title": "...",
+      "lastUpdated": "...",
+      "highlights": [ { "groupId": "...", "color": "...", "ranges": [...], "updatedAt": 0 } ],
+      "deletedGroupIds": { "<groupId>": 0 }
+    }
+  },
+  "deletedUrls": { "<url>": 1735800000000 }
+}
+```
+
+- `pages`, `deletedUrls`는 기존 `sync_meta.pages`/`deletedUrls`와 동일한 역할이지만 URL별 예산 관리가 필요 없으므로 리스트가 아닌 단순 맵으로 단순화
+- 페이지 단위 병합은 기존 `mergeHighlights(localData, remoteData)`를 **URL별로 순회하며 그대로 재사용**
+- 설정은 기존과 동일하게 last-write-wins(`updatedAt` 비교)
+
+KV에는 이 JSON을 그대로 두지 않고, 암호화한 봉투(envelope)를 저장한다.
+
+```json
+{
+  "v": 1,
+  "iv": "<base64, 12bytes>",
+  "ciphertext": "<base64>"
+}
+```
+
+---
+
+## 5) 암호화
+
+- 알고리즘: **AES-GCM 256**
+- 매 저장 시 새 IV(96bit) 생성 — 같은 키로 IV 재사용 금지
+- 인증 태그는 GCM 특성상 ciphertext에 포함되므로 별도 저장 불필요
+
+```js
+async function encryptBlob(blobObj, encryptionKey) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = utf8(JSON.stringify(blobObj));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, encryptionKey, plaintext);
+  return { v: 1, iv: toBase64(iv), ciphertext: toBase64(ciphertext) };
+}
+
+async function decryptBlob(envelope, encryptionKey) {
+  const iv = fromBase64(envelope.iv);
+  const ciphertext = fromBase64(envelope.ciphertext);
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, encryptionKey, ciphertext);
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+```
+
+---
+
+## 6) Cloudflare Worker API
+
+| 메서드 | 경로 | 동작 |
+|---|---|---|
+| GET | `/blob/:keyId` | KV에서 envelope 조회, 없으면 404 |
+| PUT | `/blob/:keyId` | body(envelope)를 KV에 저장. 크기 상한 초과 시 413 |
+| DELETE | `/blob/:keyId` | 사용자가 명시적으로 클라우드 데이터 삭제 요청 시 |
+
+```js
+// worker/src/index.js (요약)
+const MAX_BODY_BYTES = 1_000_000; // 1MB 상한(안전장치, 어뷰징 방어 아님)
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const match = url.pathname.match(/^\/blob\/([a-f0-9]{32})$/);
+    if (!match) return new Response('Not Found', { status: 404 });
+    const keyId = match[1];
+    const kvKey = `blob:${keyId}`;
+
+    if (request.method === 'GET') {
+      const value = await env.SYNC_KV.get(kvKey);
+      return value
+        ? new Response(value, { headers: { 'Content-Type': 'application/json' } })
+        : new Response('Not Found', { status: 404 });
+    }
+
+    if (request.method === 'PUT') {
+      const body = await request.text();
+      if (new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES) {
+        return new Response('Payload Too Large', { status: 413 });
+      }
+      await env.SYNC_KV.put(kvKey, body);
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === 'DELETE') {
+      await env.SYNC_KV.delete(kvKey);
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response('Method Not Allowed', { status: 405 });
+  },
+};
+```
+
+```toml
+# worker/wrangler.toml (요약)
+name = "text-highlighter-sync"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+kv_namespaces = [
+  { binding = "SYNC_KV", id = "<production-kv-namespace-id>" }
+]
+```
+
+- Worker ↔ KV는 `wrangler.toml`의 바인딩으로 연결되며 별도 API 키 불필요
+- 배포용 Cloudflare 계정 API 토큰은 CI/개발자 로컬에만 존재, 확장 프로그램 코드에는 포함되지 않음
+
+---
+
+## 7) 클라이언트 동기화 흐름
+
+```
+1. GET  /blob/:keyId         → envelope (없으면 최초 업로드로 처리)
+2. decryptBlob(envelope)     → remoteBlob
+3. buildLocalBlob()          → localBlob (storage.local 전체를 4)의 스키마로 변환)
+4. URL 합집합에 대해 mergeHighlights(local, remote) 반복 적용 + 설정 last-write-wins 병합
+5. 병합 결과를 storage.local에 반영 + 열린 탭 브로드캐스트
+6. encryptBlob(merged)       → envelope
+7. PUT /blob/:keyId          → 서버 반영
+```
+
+### 트리거 시점
+
+- 확장 프로그램/브라우저 시작 시 1회
+- `browser.alarms`로 주기적 실행 (예: 15분 간격)
+- 옵션/팝업의 "지금 동기화" 수동 버튼
+- 하이라이트 변경 자체는 기존과 동일하게 로컬에 즉시 저장하고, 클라우드 push는 위 트리거 시점에만 배치로 수행(디바운스) — 이 배치 방식 덕분에 KV 쓰기 1,000/일 한도 안에서 여유 있게 동작
+
+---
+
+## 8) 코드 구조 제안
+
+| 파일 | 역할 |
+|---|---|
+| `shared/crypto-utils.js` | `generateSyncCode`, `deriveSyncKeys`, `encryptBlob`, `decryptBlob` |
+| `background/cloud-sync-service.js` | pull-merge-push 흐름, alarm 등록, `sync-service.js`의 `mergeHighlights` 재사용 |
+| `constants/storage-keys.js` | `CLOUD_SYNC_ENABLED`, `CLOUD_SYNC_CODE`, `CLOUD_SYNC_LAST_SYNCED_AT` 등 키 추가 |
+| `options.html`/`options.js` (신규 또는 기존 팝업 확장) | 코드 생성/표시/입력 UI, 동기화 상태 표시 |
+| `worker/` (신규 디렉토리, 별도 배포 단위) | Worker 소스 + `wrangler.toml` |
+| `manifest.json`, `manifest-firefox.json` | Worker 도메인에 대한 `host_permissions` 추가 |
+
+`background/sync-service.js`(브라우저 `storage.sync`)는 그대로 유지하고, `cloud-sync-service.js`는 별도 옵트인 기능으로 추가한다. 두 방식을 동시에 켤 때의 상호작용(중복 push 등)은 1차 구현 범위에서는 다루지 않고, 우선 "브라우저 sync 미지원 환경(Firefox Android)"을 위한 대안 경로로 도입하는 것을 전제로 한다.
+
+---
+
+## 9) 1차 구현 범위와 이후 과제
+
+**포함**
+- Worker + KV 배포, 블롭 GET/PUT/DELETE
+- 클라이언트 암호화(HKDF + AES-GCM)
+- pull-merge-push 동기화 흐름 + alarm 기반 주기 실행
+- 동기화 코드 생성/입력 UI, 분실 안내
+- payload 크기 상한(1MB) — 버그로 인한 비정상 데이터 방지 목적의 기본 안전장치
+
+**제외 (문제가 확인되면 대응)**
+- IP/계정 기준 rate limiting
+- CAPTCHA/Turnstile 등 추가 봇 방어
+- 서버측 사용자 인증(계정 등록 절차)
+- 다중 동기화 방식(브라우저 sync + 클라우드 동기화) 동시 활성화 시의 충돌 처리
+
+---
+
+## 10) 구현 단계 (제안)
+
+1. Worker/KV 인프라: `wrangler.toml` 작성, KV 네임스페이스 생성, Worker 배포, 수동 curl 테스트
+2. `shared/crypto-utils.js`: 코드 생성/파생/암복호화 유닛 테스트
+3. `background/cloud-sync-service.js`: 블롭 빌드/병합/push, `mergeHighlights` 재사용 검증
+4. `browser.alarms` 등록 + 수동 동기화 진입점(메시지 라우팅에 액션 추가)
+5. 온보딩 UI: 코드 생성/복사/입력 화면, 동기화 상태(마지막 동기화 시각, 실패 여부) 표시
+6. manifest에 `host_permissions` 추가 (Chrome/Firefox 양쪽)
+7. E2E/유닛 테스트: 2-기기 시뮬레이션(pull-merge-push), 코드 오입력 시 복호화 실패 처리, 오프라인 후 복귀 시나리오
+8. Firefox Android 실기기(또는 에뮬레이터) 수동 검증
+
+---
+
+## 참고
+
+- `background/sync-service.js` — 기존 `storage.sync` 구현 및 `mergeHighlights`
+- `arch-docs/sync-requirements.md` — 동기화 요구사항/충돌 해결 원칙
+- `arch-docs/bookmark-sync-based-sync-design.md` — 북마크 기반 대안 설계(비교 참고)

--- a/arch-docs/cloudflare-kv-based-sync-design.md
+++ b/arch-docs/cloudflare-kv-based-sync-design.md
@@ -175,7 +175,7 @@ async function decryptBlob(envelope, encryptionKey) {
 | 메서드 | 경로 | 동작 |
 |---|---|---|
 | GET | `/blob/:keyId` | KV에서 envelope 조회, 없으면 404 |
-| PUT | `/blob/:keyId` | body(envelope)를 KV에 저장. 크기 상한 초과 시 413 |
+| PUT | `/blob/:keyId` | body(envelope)를 KV에 저장. 크기 상한 초과 시 413. 1년 `expirationTtl` 부여(매 PUT마다 갱신되어, 코드가 방치되면 자연 소멸) |
 | DELETE | `/blob/:keyId` | 사용자가 명시적으로 클라우드 데이터 삭제 요청 시 |
 
 ```js
@@ -276,6 +276,7 @@ kv_namespaces = [
 - pull-merge-push 동기화 흐름 + alarm 기반 주기 실행
 - 동기화 코드 생성/입력 UI, 분실 안내
 - payload 크기 상한(1MB) — 버그로 인한 비정상 데이터 방지 목적의 기본 안전장치
+- 클라우드 동기화 변경사항 없을 시 push 스킵(불필요한 KV 쓰기 방지) + KV 블롭 1년 TTL(방치된 코드의 자연 소멸)
 
 **제외 (문제가 확인되면 대응)**
 - IP/계정 기준 rate limiting

--- a/arch-docs/message-routing-matrix.md
+++ b/arch-docs/message-routing-matrix.md
@@ -21,6 +21,12 @@ Source of truth: `background/message-router.js`
 | `clearAllHighlights` | `url`, `notifyRefresh?` | `success`, `error?` | local storage remove, sync remove, tab broadcast (optional) | `handleClearAllHighlights` |
 | `getAllHighlightedPages` | none | `success`, `pages`, `error?` | local storage read | `handleGetAllHighlightedPages` |
 | `deleteAllHighlightedPages` | none | `success`, `deletedCount`, `error?` | local storage remove, sync clear | `handleDeleteAllHighlightedPages` |
+| `getCloudSyncStatus` | none | `success`, `enabled`, `code`, `lastSyncedAt`, `lastError` | local storage read | `handleGetCloudSyncStatus` |
+| `enableCloudSync` | none | `success`, `code`, `error?` | local storage write, Cloudflare Worker fetch (pull-merge-push) | `handleEnableCloudSync` |
+| `pairCloudSync` | `code` | `success`, `error?` | local storage write, Cloudflare Worker fetch (pull-merge-push) | `handlePairCloudSync` |
+| `disableCloudSync` | none | `success`, `error?` | local storage write | `handleDisableCloudSync` |
+| `resetCloudSyncCode` | none | `success`, `error?` | local storage write | `handleResetCloudSyncCode` |
+| `triggerCloudSync` | none | `success`, `error?` | local storage read/write, tab broadcast, Cloudflare Worker fetch (pull-merge-push) | `handleTriggerCloudSync` |
 
 ## Notes
 - Unknown actions return `{ success: false, error }`.

--- a/background.js
+++ b/background.js
@@ -9,6 +9,7 @@ import {
 import { initContextMenus } from './background/context-menu.js';
 import { registerMessageRouter } from './background/message-router.js';
 import { initSyncListener, migrateLocalToSync } from './background/sync-service.js';
+import { initCloudSyncAlarm, runCloudSync } from './background/cloud-sync-service.js';
 
 // ===================================================================
 // Top-level listener registration
@@ -29,6 +30,8 @@ initSyncListener({
   },
 });
 
+initCloudSyncAlarm();
+
 browserAPI.runtime.onInstalled.addListener(async () => {
   if (DEBUG_MODE) console.log('Extension installed/updated. Debug mode:', DEBUG_MODE);
 });
@@ -43,6 +46,7 @@ browserAPI.runtime.onInstalled.addListener(async () => {
     await loadCustomColors();
     await createOrUpdateContextMenus();
     await migrateLocalToSync();
+    runCloudSync().catch(e => console.error('Initial cloud sync failed', e));
   } catch (e) {
     console.error('Initialization error in background script', e);
   }

--- a/background/cloud-sync-service.js
+++ b/background/cloud-sync-service.js
@@ -1,0 +1,339 @@
+import { browserAPI } from '../shared/browser-api.js';
+import { debugLog } from '../shared/logger.js';
+import { broadcastToTabsByUrl } from '../shared/tab-broadcast.js';
+import { STORAGE_KEYS, CLOUD_SYNC_KEYS } from '../constants/storage-keys.js';
+import {
+  CLOUD_SYNC_ENDPOINT_BASE,
+  CLOUD_SYNC_ALARM_NAME,
+  CLOUD_SYNC_ALARM_PERIOD_MINUTES,
+  CLOUD_SYNC_MAX_BODY_BYTES,
+} from '../constants/cloud-sync-config.js';
+import { generateSyncCode, deriveSyncKeys, encryptBlob, decryptBlob } from '../shared/crypto-utils.js';
+import { mergeHighlights, cleanupTombstones } from './sync-service.js';
+import { applySettingsFromSync, createOrUpdateContextMenus } from './settings-service.js';
+
+const LOCAL_ONLY_KEYS = new Set([
+  STORAGE_KEYS.CUSTOM_COLORS,
+  STORAGE_KEYS.SYNC_MIGRATION_DONE,
+  STORAGE_KEYS.MINIMAP_VISIBLE,
+  STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE,
+  STORAGE_KEYS.SHORTCUT_COLOR_MAP,
+  CLOUD_SYNC_KEYS.ENABLED,
+  CLOUD_SYNC_KEYS.CODE,
+  CLOUD_SYNC_KEYS.LAST_SYNCED_AT,
+  CLOUD_SYNC_KEYS.LAST_ERROR,
+  CLOUD_SYNC_KEYS.DELETED_URLS,
+  CLOUD_SYNC_KEYS.SETTINGS_UPDATED_AT,
+  'settings', // storage.sync settings payload key, never present in storage.local but guard anyway
+]);
+
+function emptyBlob() {
+  return {
+    version: 1,
+    updatedAt: 0,
+    settings: {
+      customColors: [],
+      minimapVisible: true,
+      selectionControlsVisible: true,
+      shortcutColorMap: null,
+      updatedAt: 0,
+    },
+    pages: {},
+    deletedUrls: {},
+  };
+}
+
+/**
+ * Build the full local blob to be encrypted and pushed, mirroring the shape
+ * described in arch-docs/cloudflare-kv-based-sync-design.md section 4.
+ */
+async function buildLocalBlob() {
+  const all = await browserAPI.storage.local.get(null);
+
+  const pages = {};
+  for (const key of Object.keys(all)) {
+    if (LOCAL_ONLY_KEYS.has(key)) continue;
+    if (key.endsWith(STORAGE_KEYS.META_SUFFIX)) continue;
+    if (!Array.isArray(all[key])) continue;
+
+    const url = key;
+    const meta = all[`${url}${STORAGE_KEYS.META_SUFFIX}`] || {};
+    pages[url] = {
+      title: meta.title || '',
+      lastUpdated: meta.lastUpdated || '',
+      highlights: all[url],
+      deletedGroupIds: meta.deletedGroupIds || {},
+    };
+  }
+
+  const deletedUrls = all[CLOUD_SYNC_KEYS.DELETED_URLS] || {};
+  cleanupTombstones(deletedUrls);
+
+  return {
+    version: 1,
+    updatedAt: Date.now(),
+    settings: {
+      customColors: all[STORAGE_KEYS.CUSTOM_COLORS] || [],
+      minimapVisible: all[STORAGE_KEYS.MINIMAP_VISIBLE] !== undefined ? all[STORAGE_KEYS.MINIMAP_VISIBLE] : true,
+      selectionControlsVisible: all[STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE] !== undefined
+        ? all[STORAGE_KEYS.SELECTION_CONTROLS_VISIBLE]
+        : true,
+      shortcutColorMap: all[STORAGE_KEYS.SHORTCUT_COLOR_MAP] || null,
+      updatedAt: all[CLOUD_SYNC_KEYS.SETTINGS_UPDATED_AT] || 0,
+    },
+    pages,
+    deletedUrls,
+  };
+}
+
+function pageTimestamp(page) {
+  if (!page || !page.lastUpdated) return 0;
+  const t = new Date(page.lastUpdated).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Merge local and remote blobs. Per-page highlight merging reuses mergeHighlights
+ * (the same conflict resolution used by browser storage.sync). Page-level tombstones
+ * are resolved the same way mergeHighlights resolves group-level tombstones: a
+ * deletion wins unless one side has since recreated the page with a newer lastUpdated.
+ */
+export function mergeBlobs(localBlob, remoteBlob) {
+  const deletedUrls = { ...localBlob.deletedUrls, ...remoteBlob.deletedUrls };
+  cleanupTombstones(deletedUrls);
+
+  const allUrls = new Set([...Object.keys(localBlob.pages), ...Object.keys(remoteBlob.pages)]);
+  const pages = {};
+
+  for (const url of allUrls) {
+    const localPage = localBlob.pages[url];
+    const remotePage = remoteBlob.pages[url];
+
+    const deletedAt = deletedUrls[url];
+    const localTime = pageTimestamp(localPage);
+    const remoteTime = pageTimestamp(remotePage);
+
+    if (deletedAt && deletedAt > Math.max(localTime, remoteTime)) {
+      continue; // Neither side has touched this page since the deletion; stays deleted.
+    }
+
+    const merged = mergeHighlights(
+      { highlights: (localPage && localPage.highlights) || [], deletedGroupIds: (localPage && localPage.deletedGroupIds) || {} },
+      { highlights: (remotePage && remotePage.highlights) || [], deletedGroupIds: (remotePage && remotePage.deletedGroupIds) || {} }
+    );
+
+    pages[url] = {
+      title: (localPage && localPage.title) || (remotePage && remotePage.title) || '',
+      lastUpdated: (localTime >= remoteTime ? localPage && localPage.lastUpdated : remotePage && remotePage.lastUpdated) || '',
+      highlights: merged.highlights,
+      deletedGroupIds: merged.deletedGroupIds,
+    };
+  }
+
+  const localSettingsAt = localBlob.settings.updatedAt || 0;
+  const remoteSettingsAt = remoteBlob.settings.updatedAt || 0;
+  const settings = remoteSettingsAt > localSettingsAt ? remoteBlob.settings : localBlob.settings;
+
+  return {
+    version: 1,
+    updatedAt: Date.now(),
+    settings,
+    pages,
+    deletedUrls,
+  };
+}
+
+function isSameHighlightState(a, b) {
+  return JSON.stringify(a || []) === JSON.stringify(b || []);
+}
+
+async function applyMergedPagesToLocal(mergedPages, deletedUrls, localPagesBefore) {
+  const saveData = {};
+  for (const [url, page] of Object.entries(mergedPages)) {
+    saveData[url] = page.highlights;
+    saveData[`${url}${STORAGE_KEYS.META_SUFFIX}`] = {
+      title: page.title,
+      lastUpdated: page.lastUpdated,
+      deletedGroupIds: page.deletedGroupIds,
+    };
+  }
+  if (Object.keys(saveData).length > 0) {
+    await browserAPI.storage.local.set(saveData);
+  }
+
+  const removeKeys = [];
+  const removedUrls = [];
+  for (const url of Object.keys(localPagesBefore)) {
+    if (!mergedPages[url] && deletedUrls[url]) {
+      removeKeys.push(url, `${url}${STORAGE_KEYS.META_SUFFIX}`);
+      removedUrls.push(url);
+    }
+  }
+  if (removeKeys.length > 0) {
+    await browserAPI.storage.local.remove(removeKeys);
+  }
+
+  return { removedUrls };
+}
+
+async function broadcastMergedPages(mergedPages, localPagesBefore, removedUrls) {
+  for (const [url, page] of Object.entries(mergedPages)) {
+    const before = localPagesBefore[url];
+    if (!before || !isSameHighlightState(before.highlights, page.highlights)) {
+      await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: page.highlights });
+    }
+  }
+  for (const url of removedUrls) {
+    await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: [] });
+  }
+}
+
+async function fetchRemoteBlob(keyId, encryptionKey) {
+  const res = await fetch(`${CLOUD_SYNC_ENDPOINT_BASE}/blob/${keyId}`);
+  if (res.status === 404) return emptyBlob();
+  if (!res.ok) throw new Error(`Failed to fetch cloud data (${res.status})`);
+
+  const envelope = await res.json();
+  try {
+    return await decryptBlob(envelope, encryptionKey);
+  } catch (e) {
+    throw new Error('Failed to decrypt cloud data (sync code may be incorrect)');
+  }
+}
+
+async function pushRemoteBlob(keyId, encryptionKey, blob) {
+  const envelope = await encryptBlob(blob, encryptionKey);
+  const body = JSON.stringify(envelope);
+  if (new TextEncoder().encode(body).byteLength > CLOUD_SYNC_MAX_BODY_BYTES) {
+    throw new Error('Cloud sync data too large');
+  }
+
+  const res = await fetch(`${CLOUD_SYNC_ENDPOINT_BASE}/blob/${keyId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  if (!res.ok) throw new Error(`Failed to push cloud data (${res.status})`);
+}
+
+export async function getCloudSyncStatus() {
+  const result = await browserAPI.storage.local.get([
+    CLOUD_SYNC_KEYS.ENABLED,
+    CLOUD_SYNC_KEYS.CODE,
+    CLOUD_SYNC_KEYS.LAST_SYNCED_AT,
+    CLOUD_SYNC_KEYS.LAST_ERROR,
+  ]);
+
+  return {
+    enabled: !!result[CLOUD_SYNC_KEYS.ENABLED],
+    code: result[CLOUD_SYNC_KEYS.CODE] || null,
+    lastSyncedAt: result[CLOUD_SYNC_KEYS.LAST_SYNCED_AT] || null,
+    lastError: result[CLOUD_SYNC_KEYS.LAST_ERROR] || null,
+  };
+}
+
+/**
+ * Pull-merge-push cycle. Safe to call repeatedly (alarm, manual button, startup).
+ * No-ops if cloud sync isn't enabled.
+ */
+export async function runCloudSync() {
+  const status = await getCloudSyncStatus();
+  if (!status.enabled || !status.code) {
+    return { success: false, error: 'Cloud sync is not enabled' };
+  }
+
+  try {
+    const { encryptionKey, keyId } = await deriveSyncKeys(status.code);
+    const localBlob = await buildLocalBlob();
+    const remoteBlob = await fetchRemoteBlob(keyId, encryptionKey);
+    const merged = mergeBlobs(localBlob, remoteBlob);
+
+    const { removedUrls } = await applyMergedPagesToLocal(merged.pages, merged.deletedUrls, localBlob.pages);
+    await broadcastMergedPages(merged.pages, localBlob.pages, removedUrls);
+
+    if (merged.settings !== localBlob.settings) {
+      const { colorsChanged } = await applySettingsFromSync(merged.settings);
+      await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.SETTINGS_UPDATED_AT]: merged.settings.updatedAt || 0 });
+      if (colorsChanged) await createOrUpdateContextMenus();
+    }
+
+    await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.DELETED_URLS]: merged.deletedUrls });
+
+    await pushRemoteBlob(keyId, encryptionKey, merged);
+
+    await browserAPI.storage.local.set({
+      [CLOUD_SYNC_KEYS.LAST_SYNCED_AT]: Date.now(),
+      [CLOUD_SYNC_KEYS.LAST_ERROR]: null,
+    });
+    debugLog('Cloud sync completed.');
+    return { success: true };
+  } catch (e) {
+    debugLog('Cloud sync failed:', e.message);
+    await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.LAST_ERROR]: e.message });
+    return { success: false, error: e.message };
+  }
+}
+
+/**
+ * Generate a brand-new sync code and enable cloud sync on this device.
+ * The caller (settings UI) is responsible for showing/copy the code so it can
+ * be entered on other devices — it is never sent anywhere.
+ */
+export async function enableCloudSyncWithNewCode() {
+  const code = generateSyncCode();
+  await browserAPI.storage.local.set({
+    [CLOUD_SYNC_KEYS.ENABLED]: true,
+    [CLOUD_SYNC_KEYS.CODE]: code,
+  });
+  const result = await runCloudSync();
+  return { code, ...result };
+}
+
+/**
+ * Enable cloud sync using a code generated on another device.
+ */
+export async function enableCloudSyncWithExistingCode(code) {
+  const trimmed = (code || '').trim();
+  try {
+    await deriveSyncKeys(trimmed);
+  } catch (e) {
+    return { success: false, error: 'Invalid sync code' };
+  }
+
+  await browserAPI.storage.local.set({
+    [CLOUD_SYNC_KEYS.ENABLED]: true,
+    [CLOUD_SYNC_KEYS.CODE]: trimmed,
+  });
+  return await runCloudSync();
+}
+
+/**
+ * Disable cloud sync on this device. The sync code is kept locally so re-enabling
+ * doesn't require re-entering it; use resetCloudSyncCode to forget it entirely.
+ */
+export async function disableCloudSync() {
+  await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.ENABLED]: false });
+}
+
+export async function resetCloudSyncCode() {
+  await browserAPI.storage.local.set({
+    [CLOUD_SYNC_KEYS.ENABLED]: false,
+    [CLOUD_SYNC_KEYS.CODE]: null,
+    [CLOUD_SYNC_KEYS.LAST_SYNCED_AT]: null,
+    [CLOUD_SYNC_KEYS.LAST_ERROR]: null,
+  });
+}
+
+/**
+ * Register the periodic alarm that drives batched cloud sync. Call once at
+ * service worker startup (top-level), alongside initSyncListener.
+ */
+export function initCloudSyncAlarm() {
+  if (!browserAPI.alarms) return;
+
+  browserAPI.alarms.create(CLOUD_SYNC_ALARM_NAME, { periodInMinutes: CLOUD_SYNC_ALARM_PERIOD_MINUTES });
+  browserAPI.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name !== CLOUD_SYNC_ALARM_NAME) return;
+    runCloudSync().catch(e => debugLog('Cloud sync alarm run failed:', e.message));
+  });
+}

--- a/background/cloud-sync-service.js
+++ b/background/cloud-sync-service.js
@@ -9,7 +9,7 @@ import {
   CLOUD_SYNC_MAX_BODY_BYTES,
 } from '../constants/cloud-sync-config.js';
 import { generateSyncCode, deriveSyncKeys, encryptBlob, decryptBlob } from '../shared/crypto-utils.js';
-import { mergeHighlights, cleanupTombstones } from './sync-service.js';
+import { mergeHighlights, cleanupTombstones, mergeTombstonesByMax } from './sync-service.js';
 import { applySettingsFromSync, createOrUpdateContextMenus } from './settings-service.js';
 
 const LOCAL_ONLY_KEYS = new Set([
@@ -99,8 +99,7 @@ function pageTimestamp(page) {
  * deletion wins unless one side has since recreated the page with a newer lastUpdated.
  */
 export function mergeBlobs(localBlob, remoteBlob) {
-  const deletedUrls = { ...localBlob.deletedUrls, ...remoteBlob.deletedUrls };
-  cleanupTombstones(deletedUrls);
+  const deletedUrls = mergeTombstonesByMax(localBlob.deletedUrls, remoteBlob.deletedUrls);
 
   const allUrls = new Set([...Object.keys(localBlob.pages), ...Object.keys(remoteBlob.pages)]);
   const pages = {};
@@ -232,9 +231,12 @@ async function broadcastMergedPages(mergedPages, localPagesBefore, removedUrls) 
   }
 }
 
-async function fetchRemoteBlob(keyId, encryptionKey) {
+async function fetchRemoteBlob(keyId, encryptionKey, { allowMissingRemote = true } = {}) {
   const res = await fetch(`${CLOUD_SYNC_ENDPOINT_BASE}/blob/${keyId}`);
-  if (res.status === 404) return emptyBlob();
+  if (res.status === 404) {
+    if (allowMissingRemote) return emptyBlob();
+    throw new Error('Cloud sync data not found (sync code may be incorrect)');
+  }
   if (!res.ok) throw new Error(`Failed to fetch cloud data (${res.status})`);
 
   const envelope = await res.json();
@@ -280,7 +282,7 @@ export async function getCloudSyncStatus() {
  * Pull-merge-push cycle. Safe to call repeatedly (alarm, manual button, startup).
  * No-ops if cloud sync isn't enabled.
  */
-export async function runCloudSync() {
+export async function runCloudSync({ allowMissingRemote = true, forcePush = false } = {}) {
   const status = await getCloudSyncStatus();
   if (!status.enabled || !status.code) {
     return { success: false, error: 'Cloud sync is not enabled' };
@@ -289,7 +291,7 @@ export async function runCloudSync() {
   try {
     const { encryptionKey, keyId } = await deriveSyncKeys(status.code);
     const localBlob = await buildLocalBlob();
-    const remoteBlob = await fetchRemoteBlob(keyId, encryptionKey);
+    const remoteBlob = await fetchRemoteBlob(keyId, encryptionKey, { allowMissingRemote });
     const merged = mergeBlobs(localBlob, remoteBlob);
 
     const { removedUrls } = await applyMergedPagesToLocal(merged.pages, merged.deletedUrls, localBlob.pages);
@@ -303,7 +305,7 @@ export async function runCloudSync() {
 
     await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.DELETED_URLS]: merged.deletedUrls });
 
-    if (isBlobContentEqual(merged, remoteBlob)) {
+    if (!forcePush && isBlobContentEqual(merged, remoteBlob)) {
       debugLog('Cloud sync: no changes since last push, skipping PUT.');
     } else {
       await pushRemoteBlob(keyId, encryptionKey, merged);
@@ -333,7 +335,7 @@ export async function enableCloudSyncWithNewCode() {
     [CLOUD_SYNC_KEYS.ENABLED]: true,
     [CLOUD_SYNC_KEYS.CODE]: code,
   });
-  const result = await runCloudSync();
+  const result = await runCloudSync({ forcePush: true });
   return { code, ...result };
 }
 
@@ -343,9 +345,10 @@ export async function enableCloudSyncWithNewCode() {
 export async function enableCloudSyncWithExistingCode(code) {
   const trimmed = (code || '').trim();
   try {
-    await deriveSyncKeys(trimmed);
+    const { encryptionKey, keyId } = await deriveSyncKeys(trimmed);
+    await fetchRemoteBlob(keyId, encryptionKey, { allowMissingRemote: false });
   } catch (e) {
-    return { success: false, error: 'Invalid sync code' };
+    return { success: false, error: e.message || 'Invalid sync code' };
   }
 
   await browserAPI.storage.local.set({

--- a/background/cloud-sync-service.js
+++ b/background/cloud-sync-service.js
@@ -147,6 +147,50 @@ function isSameHighlightState(a, b) {
   return JSON.stringify(a || []) === JSON.stringify(b || []);
 }
 
+function sortedEntries(obj) {
+  const sorted = {};
+  for (const key of Object.keys(obj || {}).sort()) {
+    sorted[key] = obj[key];
+  }
+  return sorted;
+}
+
+function canonicalPage(page) {
+  if (!page) return null;
+  const highlights = [...(page.highlights || [])].sort((a, b) =>
+    (a.groupId || '').localeCompare(b.groupId || '')
+  );
+  return {
+    title: page.title || '',
+    lastUpdated: page.lastUpdated || '',
+    highlights,
+    deletedGroupIds: sortedEntries(page.deletedGroupIds),
+  };
+}
+
+/**
+ * Order-insensitive comparison of the syncable content of two blobs. Ignores
+ * the top-level `updatedAt` stamp (regenerated on every merge, carries no
+ * signal about whether anything changed) and sorts pages/highlights/tombstone
+ * maps before comparing, since mergeBlobs/mergeHighlights build those from
+ * Map/Set iteration and spreads whose key order depends on which side
+ * (local vs remote) happened to be processed first.
+ */
+export function isBlobContentEqual(a, b) {
+  const canonicalize = (blob) => {
+    const pages = {};
+    for (const url of Object.keys(blob.pages || {}).sort()) {
+      pages[url] = canonicalPage(blob.pages[url]);
+    }
+    return JSON.stringify({
+      settings: blob.settings,
+      pages,
+      deletedUrls: sortedEntries(blob.deletedUrls),
+    });
+  };
+  return canonicalize(a) === canonicalize(b);
+}
+
 async function applyMergedPagesToLocal(mergedPages, deletedUrls, localPagesBefore) {
   const saveData = {};
   for (const [url, page] of Object.entries(mergedPages)) {
@@ -259,7 +303,11 @@ export async function runCloudSync() {
 
     await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.DELETED_URLS]: merged.deletedUrls });
 
-    await pushRemoteBlob(keyId, encryptionKey, merged);
+    if (isBlobContentEqual(merged, remoteBlob)) {
+      debugLog('Cloud sync: no changes since last push, skipping PUT.');
+    } else {
+      await pushRemoteBlob(keyId, encryptionKey, merged);
+    }
 
     await browserAPI.storage.local.set({
       [CLOUD_SYNC_KEYS.LAST_SYNCED_AT]: Date.now(),

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -11,6 +11,14 @@ import {
   saveSettingsToSync,
 } from './sync-service.js';
 import {
+  getCloudSyncStatus,
+  enableCloudSyncWithNewCode,
+  enableCloudSyncWithExistingCode,
+  disableCloudSync,
+  resetCloudSyncCode,
+  runCloudSync,
+} from './cloud-sync-service.js';
+import {
   getPlatformInfo,
   getCurrentColors,
   addCustomColor,
@@ -255,6 +263,7 @@ async function handleGetAllHighlightedPages(_message) {
 async function handleDeleteAllHighlightedPages(_message) {
   const result = await browserAPI.storage.local.get(null);
   const keysToDelete = [];
+  const urls = [];
 
   const skipKeys = new Set([
     STORAGE_KEYS.CUSTOM_COLORS,
@@ -268,16 +277,47 @@ async function handleDeleteAllHighlightedPages(_message) {
     if (skipKeys.has(key)) continue;
     if (Array.isArray(result[key]) && result[key].length > 0 && !key.endsWith(STORAGE_KEYS.META_SUFFIX)) {
       keysToDelete.push(key, `${key}${STORAGE_KEYS.META_SUFFIX}`);
+      urls.push(key);
     }
   }
 
   if (keysToDelete.length > 0) {
     await browserAPI.storage.local.remove(keysToDelete);
     debugLog('All highlighted pages deleted:', keysToDelete);
-    await clearAllSyncedHighlights();
+    await clearAllSyncedHighlights(urls);
   }
 
   return successResponse({ deletedCount: keysToDelete.length / 2 });
+}
+
+async function handleGetCloudSyncStatus(_message) {
+  return successResponse(await getCloudSyncStatus());
+}
+
+async function handleEnableCloudSync(_message) {
+  const result = await enableCloudSyncWithNewCode();
+  return successResponse(result);
+}
+
+async function handlePairCloudSync(message) {
+  if (!message.code) return errorResponse('Missing sync code');
+  const result = await enableCloudSyncWithExistingCode(message.code);
+  return result.success ? successResponse(result) : errorResponse(result.error);
+}
+
+async function handleDisableCloudSync(_message) {
+  await disableCloudSync();
+  return successResponse();
+}
+
+async function handleResetCloudSyncCode(_message) {
+  await resetCloudSyncCode();
+  return successResponse();
+}
+
+async function handleTriggerCloudSync(_message) {
+  const result = await runCloudSync();
+  return result.success ? successResponse(result) : errorResponse(result.error);
 }
 
 // ===================================================================
@@ -302,6 +342,12 @@ const ACTION_HANDLERS = {
   clearAllHighlights:        handleClearAllHighlights,
   getAllHighlightedPages:    handleGetAllHighlightedPages,
   deleteAllHighlightedPages: handleDeleteAllHighlightedPages,
+  getCloudSyncStatus:        handleGetCloudSyncStatus,
+  enableCloudSync:           handleEnableCloudSync,
+  pairCloudSync:             handlePairCloudSync,
+  disableCloudSync:          handleDisableCloudSync,
+  resetCloudSyncCode:        handleResetCloudSyncCode,
+  triggerCloudSync:          handleTriggerCloudSync,
 };
 
 /**

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -1,7 +1,7 @@
 import { browserAPI } from '../shared/browser-api.js';
 import { debugLog } from '../shared/logger.js';
 import { broadcastToTabsByUrl } from '../shared/tab-broadcast.js';
-import { STORAGE_KEYS, SYNC_KEYS } from '../constants/storage-keys.js';
+import { STORAGE_KEYS, SYNC_KEYS, CLOUD_SYNC_KEYS } from '../constants/storage-keys.js';
 
 const SYNC_QUOTA_BYTES_PER_ITEM = 8192;
 // Reserve space for settings and sync_meta
@@ -130,11 +130,32 @@ export async function saveSettingsToSync() {
     }
   }
 
+  // Recorded regardless of storage.sync outcome so the cloud sync blob (which has no
+  // event-based change detection of its own) can tell whose settings are newest.
+  await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.SETTINGS_UPDATED_AT]: Date.now() });
+
   try {
     await browserAPI.storage.sync.set({ [SYNC_SETTINGS_KEY]: settings });
     debugLog('Settings saved to sync:', settings);
   } catch (e) {
     debugLog('Failed to save settings to sync:', e.message);
+  }
+}
+
+/**
+ * Record a local tombstone for cloud sync (Cloudflare KV blob), independent of
+ * browser storage.sync's own tombstone bookkeeping (sync_meta.deletedUrls).
+ */
+async function recordCloudSyncTombstones(urls) {
+  try {
+    const result = await browserAPI.storage.local.get(CLOUD_SYNC_KEYS.DELETED_URLS);
+    const deletedUrls = result[CLOUD_SYNC_KEYS.DELETED_URLS] || {};
+    const now = Date.now();
+    for (const url of urls) deletedUrls[url] = now;
+    cleanupTombstones(deletedUrls);
+    await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.DELETED_URLS]: deletedUrls });
+  } catch (e) {
+    debugLog('Failed to record cloud sync tombstone(s):', e.message);
   }
 }
 
@@ -229,6 +250,8 @@ export async function syncRemoveHighlights(url) {
   } catch (e) {
     debugLog('Failed to remove highlights from sync:', e.message);
   }
+
+  await recordCloudSyncTombstones([url]);
 }
 
 export async function cleanupEmptyHighlightData(url) {
@@ -251,8 +274,13 @@ async function applyUserDeletionFromSync(url) {
  * Clear all synced highlights and mark synced URLs as user-deleted.
  * Tombstones are written only for URLs currently tracked in sync_meta.pages
  * to keep the sync_meta item within per-item quota.
+ *
+ * @param {string[]} localUrls - All locally known highlighted page URLs at the time of
+ *   clearing (may be a superset of sync_meta.pages, e.g. pages that never fit the 8KB
+ *   per-item browser sync limit). Used to record cloud sync tombstones for every page,
+ *   since the Cloudflare KV blob has no per-item size limit of its own.
  */
-export async function clearAllSyncedHighlights() {
+export async function clearAllSyncedHighlights(localUrls = []) {
   try {
     const meta = await getSyncMeta();
     const syncKeysToRemove = meta.pages.map(p => p.syncKey);
@@ -273,6 +301,8 @@ export async function clearAllSyncedHighlights() {
   } catch (e) {
     debugLog('Failed to clear synced highlights:', e.message);
   }
+
+  await recordCloudSyncTombstones(localUrls);
 }
 
 /**

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -31,6 +31,17 @@ export function cleanupTombstones(obj) {
   }
 }
 
+export function mergeTombstonesByMax(localDeleted = {}, remoteDeleted = {}) {
+  const mergedDeleted = {};
+  for (const deleted of [localDeleted, remoteDeleted]) {
+    for (const [id, deletedAt] of Object.entries(deleted || {})) {
+      mergedDeleted[id] = Math.max(mergedDeleted[id] || 0, deletedAt || 0);
+    }
+  }
+  cleanupTombstones(mergedDeleted);
+  return mergedDeleted;
+}
+
 export function normalizeSyncMeta(rawMeta) {
   const meta = rawMeta || {};
   if (!Array.isArray(meta.pages)) meta.pages = [];
@@ -68,9 +79,8 @@ export function mergeHighlights(localData, remoteData) {
   const localDeleted = localData.deletedGroupIds || {};
   const remoteDeleted = remoteData.deletedGroupIds || {};
 
-  // 1. Merge deleted markers (Tombstones) - Union and Cleanup
-  const mergedDeleted = { ...localDeleted, ...remoteDeleted };
-  cleanupTombstones(mergedDeleted);
+  // 1. Merge deleted markers (Tombstones) - Union by newest timestamp and Cleanup
+  const mergedDeleted = mergeTombstonesByMax(localDeleted, remoteDeleted);
 
   // 2. Combine all highlight groups, favoring newer versions
   const allGroupsMap = new Map();

--- a/constants/cloud-sync-config.js
+++ b/constants/cloud-sync-config.js
@@ -1,0 +1,8 @@
+// Base URL of the deployed Cloudflare Worker (see worker/README.md for deployment steps).
+// Replace this placeholder with your actual *.workers.dev URL after `wrangler deploy`,
+// and update the matching host_permissions entry in manifest.json / manifest-firefox.json.
+export const CLOUD_SYNC_ENDPOINT_BASE = 'https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev';
+
+export const CLOUD_SYNC_ALARM_NAME = 'cloudSyncAlarm';
+export const CLOUD_SYNC_ALARM_PERIOD_MINUTES = 15;
+export const CLOUD_SYNC_MAX_BODY_BYTES = 1_000_000;

--- a/constants/cloud-sync-config.js
+++ b/constants/cloud-sync-config.js
@@ -1,7 +1,7 @@
 // Base URL of the deployed Cloudflare Worker (see worker/README.md for deployment steps).
 // Replace this placeholder with your actual *.workers.dev URL after `wrangler deploy`,
 // and update the matching host_permissions entry in manifest.json / manifest-firefox.json.
-export const CLOUD_SYNC_ENDPOINT_BASE = 'https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev';
+export const CLOUD_SYNC_ENDPOINT_BASE = 'https://text-highlighter-sync.cuspymd.workers.dev';
 
 export const CLOUD_SYNC_ALARM_NAME = 'cloudSyncAlarm';
 export const CLOUD_SYNC_ALARM_PERIOD_MINUTES = 15;

--- a/constants/storage-keys.js
+++ b/constants/storage-keys.js
@@ -12,3 +12,12 @@ export const SYNC_KEYS = {
   HIGHLIGHT_PREFIX: 'hl_',
   META: 'sync_meta',
 };
+
+export const CLOUD_SYNC_KEYS = {
+  ENABLED: 'cloudSyncEnabled',
+  CODE: 'cloudSyncCode',
+  LAST_SYNCED_AT: 'cloudSyncLastSyncedAt',
+  LAST_ERROR: 'cloudSyncLastError',
+  DELETED_URLS: 'cloudSyncDeletedUrls',
+  SETTINGS_UPDATED_AT: 'cloudSyncSettingsUpdatedAt',
+};

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -8,7 +8,11 @@
     "storage",
     "contextMenus",
     "activeTab",
-    "tabs"
+    "tabs",
+    "alarms"
+  ],
+  "host_permissions": [
+    "https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev/*"
   ],
   "background": {
     "scripts": [

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -12,7 +12,7 @@
     "alarms"
   ],
   "host_permissions": [
-    "https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev/*"
+    "https://text-highlighter-sync.cuspymd.workers.dev/*"
   ],
   "background": {
     "scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,11 @@
     "storage",
     "contextMenus",
     "activeTab",
-    "tabs"
+    "tabs",
+    "alarms"
+  ],
+  "host_permissions": [
+    "https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev/*"
   ],
   "background": {
     "service_worker": "background.js",

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "alarms"
   ],
   "host_permissions": [
-    "https://text-highlighter-sync.YOUR_SUBDOMAIN.workers.dev/*"
+    "https://text-highlighter-sync.cuspymd.workers.dev/*"
   ],
   "background": {
     "service_worker": "background.js",

--- a/mocks/chrome.js
+++ b/mocks/chrome.js
@@ -64,4 +64,10 @@ export default {
       addListener: jest.fn(),
     },
   },
+  alarms: {
+    create: jest.fn(),
+    onAlarm: {
+      addListener: jest.fn(),
+    },
+  },
 };

--- a/settings.html
+++ b/settings.html
@@ -323,6 +323,72 @@
         padding: 10px 0;
       }
 
+      /* Cloud Sync */
+      .cloud-sync-pair-row {
+        display: flex;
+        gap: 8px;
+        margin-top: 10px;
+      }
+
+      .cloud-sync-code-input {
+        flex: 1;
+        min-width: 0;
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: var(--surface-strong);
+        color: var(--text);
+        font-size: 13px;
+        font-family: monospace;
+        outline: none;
+      }
+
+      .cloud-sync-code-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--border);
+      }
+
+      .cloud-sync-code-row > span {
+        font-size: 13px;
+        color: var(--muted);
+        flex: 0 0 auto;
+      }
+
+      .cloud-sync-code-value {
+        flex: 1;
+        min-width: 0;
+        font-family: monospace;
+        font-size: 12px;
+        word-break: break-all;
+        background: var(--surface-strong);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 4px 6px;
+      }
+
+      .cloud-sync-status-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 10px 0;
+      }
+
+      .cloud-sync-status-row .hint-text {
+        margin: 0;
+      }
+
+      .cloud-sync-error-text {
+        color: var(--danger);
+      }
+
+      #cloud-sync-reset-btn {
+        margin-top: 12px;
+      }
+
 </style>
   </head>
   <body>
@@ -356,6 +422,56 @@
         <div id="custom-colors-list"></div>
         <button id="add-custom-color-btn" class="btn btn-primary" data-i18n="addCustomColor">+ Add Custom Color</button>
         <input type="color" id="color-picker-hidden" style="display:none" />
+      </section>
+
+      <!-- Cloud Sync Section -->
+      <section class="section-card" id="cloud-sync-section">
+        <h2 class="section-title" data-i18n="cloudSyncSection">Cloud Sync (Beta)</h2>
+        <p class="hint-text" data-i18n="cloudSyncIntro">
+          Sync highlights across devices via an encrypted cloud backup, for platforms
+          (like Firefox for Android) where browser sync isn't available. Your data is
+          encrypted on this device before upload; the sync code is the only way to decrypt it.
+        </p>
+
+        <div id="cloud-sync-setup">
+          <button id="cloud-sync-generate-btn" class="btn btn-primary" data-i18n="cloudSyncGenerateCode">Generate New Code</button>
+          <div class="cloud-sync-pair-row">
+            <input
+              type="text"
+              id="cloud-sync-pair-input"
+              class="cloud-sync-code-input"
+              data-i18n="cloudSyncPairCodePlaceholder"
+              placeholder="Enter sync code from another device"
+            />
+            <button id="cloud-sync-pair-btn" class="btn" data-i18n="cloudSyncPairCodeButton">Connect</button>
+          </div>
+        </div>
+
+        <div id="cloud-sync-connected" style="display:none">
+          <div class="toggle-container">
+            <label for="cloud-sync-toggle" data-i18n="cloudSyncEnabledLabel">Cloud Sync</label>
+            <label class="toggle-switch">
+              <input type="checkbox" id="cloud-sync-toggle" />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="cloud-sync-code-row">
+            <span data-i18n="cloudSyncYourCode">Your Sync Code</span>
+            <code id="cloud-sync-code-display" class="cloud-sync-code-value"></code>
+            <button id="cloud-sync-copy-btn" class="btn-icon" data-i18n="cloudSyncCopyCode">Copy</button>
+          </div>
+          <p class="hint-text" data-i18n="cloudSyncSaveCodeWarning">
+            Save this code somewhere safe. If you lose it, this data cannot be recovered.
+          </p>
+
+          <div class="cloud-sync-status-row">
+            <span id="cloud-sync-status-text" class="hint-text"></span>
+            <button id="cloud-sync-now-btn" class="btn" data-i18n="cloudSyncNowButton">Sync Now</button>
+          </div>
+
+          <button id="cloud-sync-reset-btn" class="btn-icon btn-danger" data-i18n="cloudSyncResetButton">Forget Code</button>
+        </div>
       </section>
 
       <!-- Keyboard Shortcuts Section -->

--- a/settings.js
+++ b/settings.js
@@ -22,7 +22,7 @@ function initializeI18n() {
   });
 }
 
-const { showAlertModal } = createLocalizedModalHelpers(
+const { showAlertModal, showConfirmModal } = createLocalizedModalHelpers(
   (key, defaultValue) => browserAPI.i18n.getMessage(key) || defaultValue
 );
 
@@ -383,6 +383,130 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderShortcutsList(commandsResult, colorMap, allColors);
   }
 
+  // --- Cloud Sync ---
+  const cloudSyncSetup = document.getElementById('cloud-sync-setup');
+  const cloudSyncConnected = document.getElementById('cloud-sync-connected');
+  const cloudSyncGenerateBtn = document.getElementById('cloud-sync-generate-btn');
+  const cloudSyncPairInput = document.getElementById('cloud-sync-pair-input');
+  const cloudSyncPairBtn = document.getElementById('cloud-sync-pair-btn');
+  const cloudSyncToggle = document.getElementById('cloud-sync-toggle');
+  const cloudSyncCodeDisplay = document.getElementById('cloud-sync-code-display');
+  const cloudSyncCopyBtn = document.getElementById('cloud-sync-copy-btn');
+  const cloudSyncStatusText = document.getElementById('cloud-sync-status-text');
+  const cloudSyncNowBtn = document.getElementById('cloud-sync-now-btn');
+  const cloudSyncResetBtn = document.getElementById('cloud-sync-reset-btn');
+
+  let currentSyncCode = null;
+
+  function renderCloudSyncStatus(status) {
+    cloudSyncToggle.checked = !!status.enabled;
+
+    if (status.lastError) {
+      cloudSyncStatusText.textContent = `${browserAPI.i18n.getMessage('cloudSyncErrorPrefix') || 'Sync error: '}${status.lastError}`;
+      cloudSyncStatusText.classList.add('cloud-sync-error-text');
+    } else if (status.lastSyncedAt) {
+      cloudSyncStatusText.textContent = `${browserAPI.i18n.getMessage('cloudSyncLastSyncedPrefix') || 'Last synced: '}${new Date(status.lastSyncedAt).toLocaleString()}`;
+      cloudSyncStatusText.classList.remove('cloud-sync-error-text');
+    } else {
+      cloudSyncStatusText.textContent = browserAPI.i18n.getMessage('cloudSyncNeverSynced') || 'Not synced yet';
+      cloudSyncStatusText.classList.remove('cloud-sync-error-text');
+    }
+  }
+
+  function renderCloudSyncView(status) {
+    currentSyncCode = status.code;
+
+    if (status.code) {
+      cloudSyncSetup.style.display = 'none';
+      cloudSyncConnected.style.display = '';
+      cloudSyncCodeDisplay.textContent = status.code;
+      renderCloudSyncStatus(status);
+    } else {
+      cloudSyncSetup.style.display = '';
+      cloudSyncConnected.style.display = 'none';
+    }
+  }
+
+  async function loadCloudSyncStatus() {
+    const response = await browserAPI.runtime.sendMessage({ action: 'getCloudSyncStatus' });
+    if (response && response.success) {
+      renderCloudSyncView(response);
+    }
+  }
+
+  cloudSyncGenerateBtn.addEventListener('click', async () => {
+    cloudSyncGenerateBtn.disabled = true;
+    try {
+      const response = await browserAPI.runtime.sendMessage({ action: 'enableCloudSync' });
+      if (response && response.success) {
+        await loadCloudSyncStatus();
+      }
+    } finally {
+      cloudSyncGenerateBtn.disabled = false;
+    }
+  });
+
+  cloudSyncPairBtn.addEventListener('click', async () => {
+    const code = cloudSyncPairInput.value.trim();
+    if (!code) return;
+
+    cloudSyncPairBtn.disabled = true;
+    try {
+      const response = await browserAPI.runtime.sendMessage({ action: 'pairCloudSync', code });
+      if (response && response.success) {
+        cloudSyncPairInput.value = '';
+        await loadCloudSyncStatus();
+      } else {
+        await showAlertModal(browserAPI.i18n.getMessage('cloudSyncInvalidCode') || "That sync code doesn't look right.");
+      }
+    } finally {
+      cloudSyncPairBtn.disabled = false;
+    }
+  });
+
+  cloudSyncToggle.addEventListener('change', async () => {
+    if (cloudSyncToggle.checked) {
+      if (currentSyncCode) {
+        await browserAPI.runtime.sendMessage({ action: 'pairCloudSync', code: currentSyncCode });
+      }
+    } else {
+      await browserAPI.runtime.sendMessage({ action: 'disableCloudSync' });
+    }
+    await loadCloudSyncStatus();
+  });
+
+  cloudSyncCopyBtn.addEventListener('click', async () => {
+    if (!currentSyncCode) return;
+    await navigator.clipboard.writeText(currentSyncCode);
+    const original = cloudSyncCopyBtn.textContent;
+    cloudSyncCopyBtn.textContent = browserAPI.i18n.getMessage('cloudSyncCodeCopied') || 'Copied!';
+    setTimeout(() => { cloudSyncCopyBtn.textContent = original; }, 1500);
+  });
+
+  cloudSyncNowBtn.addEventListener('click', async () => {
+    cloudSyncNowBtn.disabled = true;
+    const originalText = cloudSyncNowBtn.textContent;
+    cloudSyncNowBtn.textContent = browserAPI.i18n.getMessage('cloudSyncSyncing') || 'Syncing...';
+    try {
+      await browserAPI.runtime.sendMessage({ action: 'triggerCloudSync' });
+      await loadCloudSyncStatus();
+    } finally {
+      cloudSyncNowBtn.disabled = false;
+      cloudSyncNowBtn.textContent = originalText;
+    }
+  });
+
+  cloudSyncResetBtn.addEventListener('click', async () => {
+    const confirmed = await showConfirmModal(
+      browserAPI.i18n.getMessage('cloudSyncResetConfirm') ||
+      'This disconnects this device and permanently forgets the sync code. Continue?'
+    );
+    if (!confirmed) return;
+
+    await browserAPI.runtime.sendMessage({ action: 'resetCloudSyncCode' });
+    await loadCloudSyncStatus();
+  });
+
   // --- Init ---
   if (!browserAPI.commands) {
     document.getElementById('shortcuts-section').style.display = 'none';
@@ -391,13 +515,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   await Promise.all([
     loadGeneralSettings(),
     loadCustomColors(),
-    loadShortcuts()
+    loadShortcuts(),
+    loadCloudSyncStatus()
   ]);
 
   window.addEventListener('focus', async () => {
     await Promise.all([
       loadCustomColors(),
-      loadShortcuts()
+      loadShortcuts(),
+      loadCloudSyncStatus()
     ]);
   });
 });

--- a/shared/crypto-utils.js
+++ b/shared/crypto-utils.js
@@ -1,0 +1,155 @@
+// Client-side cryptography for cloud sync (see arch-docs/cloudflare-kv-based-sync-design.md).
+// The sync code never leaves the device; only the derived keyId (an opaque lookup key)
+// and AES-GCM ciphertext are sent to the Worker.
+
+const CROCKFORD_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const SYNC_CODE_BYTE_LENGTH = 32; // 256bit
+const HKDF_INFO_ENCRYPT = 'th-sync-encrypt-v1';
+const HKDF_INFO_KEYID = 'th-sync-keyid-v1';
+const GCM_IV_BYTE_LENGTH = 12;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function encodeCrockfordBase32(bytes) {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += CROCKFORD_ALPHABET[(value >>> bits) & 31];
+    }
+  }
+
+  if (bits > 0) {
+    output += CROCKFORD_ALPHABET[(value << (5 - bits)) & 31];
+  }
+
+  return output;
+}
+
+function decodeCrockfordBase32(input) {
+  const normalized = input
+    .toUpperCase()
+    .replace(/[-\s]/g, '')
+    .replace(/O/g, '0')
+    .replace(/[IL]/g, '1');
+
+  let bits = 0;
+  let value = 0;
+  const bytes = [];
+
+  for (const ch of normalized) {
+    const idx = CROCKFORD_ALPHABET.indexOf(ch);
+    if (idx === -1) {
+      throw new Error(`Invalid sync code character: ${ch}`);
+    }
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >>> bits) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+function groupForDisplay(code, groupSize = 4) {
+  const groups = [];
+  for (let i = 0; i < code.length; i += groupSize) {
+    groups.push(code.slice(i, i + groupSize));
+  }
+  return groups.join('-');
+}
+
+/**
+ * Generate a new random sync code (256bit), formatted for display/copying.
+ */
+export function generateSyncCode() {
+  const bytes = crypto.getRandomValues(new Uint8Array(SYNC_CODE_BYTE_LENGTH));
+  return groupForDisplay(encodeCrockfordBase32(bytes));
+}
+
+function bytesToBase64(bytes) {
+  const CHUNK_SIZE = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function toHex(bytes) {
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Derive the AES-GCM encryption key and the opaque keyId from a sync code.
+ * Both values are deterministic: entering the same code on another device
+ * yields identical results without any server round-trip.
+ */
+export async function deriveSyncKeys(syncCode) {
+  const codeBytes = decodeCrockfordBase32(syncCode);
+  if (codeBytes.length !== SYNC_CODE_BYTE_LENGTH) {
+    throw new Error('Invalid sync code length');
+  }
+
+  const baseKey = await crypto.subtle.importKey(
+    'raw', codeBytes, 'HKDF', false, ['deriveKey', 'deriveBits']
+  );
+
+  const encryptionKey = await crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: textEncoder.encode(HKDF_INFO_ENCRYPT) },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+
+  const keyIdBits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: textEncoder.encode(HKDF_INFO_KEYID) },
+    baseKey,
+    128
+  );
+
+  return { encryptionKey, keyId: toHex(new Uint8Array(keyIdBits)) };
+}
+
+/**
+ * Encrypt a JSON-serializable blob into the envelope stored on the server.
+ */
+export async function encryptBlob(blobObj, encryptionKey) {
+  const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_BYTE_LENGTH));
+  const plaintext = textEncoder.encode(JSON.stringify(blobObj));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, encryptionKey, plaintext);
+
+  return {
+    v: 1,
+    iv: bytesToBase64(iv),
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+  };
+}
+
+/**
+ * Decrypt an envelope previously produced by encryptBlob back into the original object.
+ */
+export async function decryptBlob(envelope, encryptionKey) {
+  const iv = base64ToBytes(envelope.iv);
+  const ciphertext = base64ToBytes(envelope.ciphertext);
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, encryptionKey, ciphertext);
+  return JSON.parse(textDecoder.decode(plaintext));
+}

--- a/tests/cloud-sync-service.test.js
+++ b/tests/cloud-sync-service.test.js
@@ -1,0 +1,180 @@
+import chrome from '../mocks/chrome.js';
+import { generateSyncCode } from '../shared/crypto-utils.js';
+import {
+  mergeBlobs,
+  getCloudSyncStatus,
+  runCloudSync,
+  enableCloudSyncWithNewCode,
+  enableCloudSyncWithExistingCode,
+  disableCloudSync,
+  initCloudSyncAlarm,
+} from '../background/cloud-sync-service.js';
+
+function emptyBlob(overrides = {}) {
+  return {
+    version: 1,
+    updatedAt: 0,
+    settings: { customColors: [], minimapVisible: true, selectionControlsVisible: true, shortcutColorMap: null, updatedAt: 0 },
+    pages: {},
+    deletedUrls: {},
+    ...overrides,
+  };
+}
+
+describe('cloud-sync-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('mergeBlobs', () => {
+    it('unions pages present on only one side', () => {
+      const local = emptyBlob({ pages: { 'https://a.test': { highlights: [{ groupId: 'g1', updatedAt: 100 }], deletedGroupIds: {}, lastUpdated: '2024-01-01T00:00:00.000Z' } } });
+      const remote = emptyBlob({ pages: { 'https://b.test': { highlights: [{ groupId: 'g2', updatedAt: 100 }], deletedGroupIds: {}, lastUpdated: '2024-01-01T00:00:00.000Z' } } });
+
+      const merged = mergeBlobs(local, remote);
+      expect(Object.keys(merged.pages).sort()).toEqual(['https://a.test', 'https://b.test']);
+    });
+
+    it('merges highlights for the same page via mergeHighlights (favors newer updatedAt)', () => {
+      const local = emptyBlob({
+        pages: { 'https://a.test': { highlights: [{ groupId: 'g1', text: 'old', updatedAt: 100 }], deletedGroupIds: {}, lastUpdated: '2024-01-01T00:00:00.000Z' } },
+      });
+      const remote = emptyBlob({
+        pages: { 'https://a.test': { highlights: [{ groupId: 'g1', text: 'new', updatedAt: 200 }], deletedGroupIds: {}, lastUpdated: '2024-01-02T00:00:00.000Z' } },
+      });
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.pages['https://a.test'].highlights).toHaveLength(1);
+      expect(merged.pages['https://a.test'].highlights[0].text).toBe('new');
+    });
+
+    it('drops a page whose tombstone is newer than both sides (stays deleted)', () => {
+      const now = Date.now();
+      const local = emptyBlob({
+        pages: { 'https://a.test': { highlights: [{ groupId: 'g1', updatedAt: 1 }], deletedGroupIds: {}, lastUpdated: new Date(now - 10000).toISOString() } },
+        deletedUrls: { 'https://a.test': now },
+      });
+      const remote = emptyBlob();
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.pages['https://a.test']).toBeUndefined();
+    });
+
+    it('keeps a page recreated after deletion (lastUpdated newer than tombstone)', () => {
+      const now = Date.now();
+      const local = emptyBlob({ deletedUrls: { 'https://a.test': now - 10000 } });
+      const remote = emptyBlob({
+        pages: { 'https://a.test': { highlights: [{ groupId: 'g1', updatedAt: now }], deletedGroupIds: {}, lastUpdated: new Date(now).toISOString() } },
+      });
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.pages['https://a.test']).toBeDefined();
+      expect(merged.pages['https://a.test'].highlights).toHaveLength(1);
+    });
+
+    it('picks settings from whichever side has the newer settings.updatedAt', () => {
+      const local = emptyBlob({ settings: { customColors: [], minimapVisible: false, selectionControlsVisible: true, shortcutColorMap: null, updatedAt: 100 } });
+      const remote = emptyBlob({ settings: { customColors: [], minimapVisible: true, selectionControlsVisible: true, shortcutColorMap: null, updatedAt: 200 } });
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.settings.minimapVisible).toBe(true);
+    });
+  });
+
+  describe('getCloudSyncStatus', () => {
+    it('returns disabled defaults when nothing is stored', async () => {
+      chrome.storage.local.get.mockResolvedValueOnce({});
+      const status = await getCloudSyncStatus();
+      expect(status).toEqual({ enabled: false, code: null, lastSyncedAt: null, lastError: null });
+    });
+  });
+
+  describe('runCloudSync', () => {
+    it('no-ops when cloud sync is disabled', async () => {
+      chrome.storage.local.get.mockResolvedValueOnce({ cloudSyncEnabled: false });
+      global.fetch = jest.fn();
+
+      const result = await runCloudSync();
+      expect(result.success).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('pulls (404 = no remote data yet), merges, and pushes when enabled', async () => {
+      const code = generateSyncCode();
+      chrome.storage.local.get.mockImplementation((keys) => {
+        if (keys === null) {
+          return Promise.resolve({
+            'https://a.test': [{ groupId: 'g1', updatedAt: 1 }],
+            'https://a.test_meta': { title: 'A', lastUpdated: '2024-01-01T00:00:00.000Z', deletedGroupIds: {} },
+          });
+        }
+        return Promise.resolve({ cloudSyncEnabled: true, cloudSyncCode: code });
+      });
+
+      global.fetch = jest.fn()
+        .mockResolvedValueOnce({ status: 404, ok: false }) // GET
+        .mockResolvedValueOnce({ ok: true, status: 204 }); // PUT
+
+      const result = await runCloudSync();
+
+      expect(result.success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch.mock.calls[1][1].method).toBe('PUT');
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(
+        expect.objectContaining({ cloudSyncLastSyncedAt: expect.any(Number), cloudSyncLastError: null })
+      );
+    });
+
+    it('records the error and returns success:false when the fetch fails', async () => {
+      const code = generateSyncCode();
+      chrome.storage.local.get.mockImplementation((keys) => {
+        if (keys === null) return Promise.resolve({});
+        return Promise.resolve({ cloudSyncEnabled: true, cloudSyncCode: code });
+      });
+      global.fetch = jest.fn().mockResolvedValueOnce({ status: 500, ok: false });
+
+      const result = await runCloudSync();
+      expect(result.success).toBe(false);
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(
+        expect.objectContaining({ cloudSyncLastError: expect.any(String) })
+      );
+    });
+  });
+
+  describe('enableCloudSyncWithNewCode / enableCloudSyncWithExistingCode', () => {
+    it('generates a new code, enables sync, and runs an initial sync', async () => {
+      chrome.storage.local.get.mockResolvedValue({});
+      global.fetch = jest.fn()
+        .mockResolvedValueOnce({ status: 404, ok: false })
+        .mockResolvedValueOnce({ ok: true, status: 204 });
+
+      const result = await enableCloudSyncWithNewCode();
+      expect(result.code).toMatch(/^[0-9A-Z]{4}(-[0-9A-Z]{4}){12}$/);
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(
+        expect.objectContaining({ cloudSyncEnabled: true, cloudSyncCode: result.code })
+      );
+    });
+
+    it('rejects a malformed pairing code without touching storage', async () => {
+      const result = await enableCloudSyncWithExistingCode('not-a-valid-code!!');
+      expect(result.success).toBe(false);
+      expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disableCloudSync', () => {
+    it('sets cloudSyncEnabled to false', async () => {
+      await disableCloudSync();
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ cloudSyncEnabled: false });
+    });
+  });
+
+  describe('initCloudSyncAlarm', () => {
+    it('registers the periodic alarm and an onAlarm listener', () => {
+      initCloudSyncAlarm();
+      expect(chrome.alarms.create).toHaveBeenCalledWith('cloudSyncAlarm', expect.objectContaining({ periodInMinutes: expect.any(Number) }));
+      expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/cloud-sync-service.test.js
+++ b/tests/cloud-sync-service.test.js
@@ -73,6 +73,33 @@ describe('cloud-sync-service', () => {
       expect(merged.pages['https://a.test'].highlights).toHaveLength(1);
     });
 
+    it('keeps the newer duplicate URL tombstone so an older remote tombstone cannot resurrect a page', () => {
+      const now = Date.now();
+      const url = 'https://a.test';
+      const localDelete = now - 1000;
+      const remoteRecreate = now - 2000;
+      const remoteOldDelete = now - 3000;
+      const local = emptyBlob({ deletedUrls: { [url]: localDelete } });
+      const remote = emptyBlob({
+        pages: { [url]: { highlights: [{ groupId: 'g1', updatedAt: remoteRecreate }], deletedGroupIds: {}, lastUpdated: new Date(remoteRecreate).toISOString() } },
+        deletedUrls: { [url]: remoteOldDelete },
+      });
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.deletedUrls[url]).toBe(localDelete);
+      expect(merged.pages[url]).toBeUndefined();
+    });
+
+    it('keeps the newer duplicate URL tombstone independent of merge direction', () => {
+      const now = Date.now();
+      const url = 'https://a.test';
+      const local = emptyBlob({ deletedUrls: { [url]: now - 3000 } });
+      const remote = emptyBlob({ deletedUrls: { [url]: now - 1000 } });
+
+      const merged = mergeBlobs(local, remote);
+      expect(merged.deletedUrls[url]).toBe(now - 1000);
+    });
+
     it('picks settings from whichever side has the newer settings.updatedAt', () => {
       const local = emptyBlob({ settings: { customColors: [], minimapVisible: false, selectionControlsVisible: true, shortcutColorMap: null, updatedAt: 100 } });
       const remote = emptyBlob({ settings: { customColors: [], minimapVisible: true, selectionControlsVisible: true, shortcutColorMap: null, updatedAt: 200 } });
@@ -214,7 +241,18 @@ describe('cloud-sync-service', () => {
 
   describe('enableCloudSyncWithNewCode / enableCloudSyncWithExistingCode', () => {
     it('generates a new code, enables sync, and runs an initial sync', async () => {
-      chrome.storage.local.get.mockResolvedValue({});
+      const localStore = {};
+      chrome.storage.local.set.mockImplementation((items) => {
+        Object.assign(localStore, items);
+        return Promise.resolve();
+      });
+      chrome.storage.local.get.mockImplementation((keys) => {
+        if (keys === null) return Promise.resolve({});
+        if (Array.isArray(keys)) {
+          return Promise.resolve(Object.fromEntries(keys.map((key) => [key, localStore[key]])));
+        }
+        return Promise.resolve({ [keys]: localStore[keys] });
+      });
       global.fetch = jest.fn()
         .mockResolvedValueOnce({ status: 404, ok: false })
         .mockResolvedValueOnce({ ok: true, status: 204 });
@@ -224,6 +262,23 @@ describe('cloud-sync-service', () => {
       expect(chrome.storage.local.set).toHaveBeenCalledWith(
         expect.objectContaining({ cloudSyncEnabled: true, cloudSyncCode: result.code })
       );
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch.mock.calls[1][1].method).toBe('PUT');
+    });
+
+    it('rejects a valid-looking existing code when no remote blob exists', async () => {
+      const code = generateSyncCode();
+      global.fetch = jest.fn().mockResolvedValueOnce({ status: 404, ok: false });
+
+      const result = await enableCloudSyncWithExistingCode(code);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found|incorrect/i);
+      expect(chrome.storage.local.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ cloudSyncEnabled: true, cloudSyncCode: code })
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch.mock.calls[0][1]).toBeUndefined();
     });
 
     it('rejects a malformed pairing code without touching storage', async () => {

--- a/tests/cloud-sync-service.test.js
+++ b/tests/cloud-sync-service.test.js
@@ -1,7 +1,8 @@
 import chrome from '../mocks/chrome.js';
-import { generateSyncCode } from '../shared/crypto-utils.js';
+import { generateSyncCode, deriveSyncKeys, encryptBlob } from '../shared/crypto-utils.js';
 import {
   mergeBlobs,
+  isBlobContentEqual,
   getCloudSyncStatus,
   runCloudSync,
   enableCloudSyncWithNewCode,
@@ -81,6 +82,34 @@ describe('cloud-sync-service', () => {
     });
   });
 
+  describe('isBlobContentEqual', () => {
+    it('treats identical content as equal even when the top-level updatedAt stamp differs', () => {
+      const a = emptyBlob({ updatedAt: 1 });
+      const b = emptyBlob({ updatedAt: 2 });
+      expect(isBlobContentEqual(a, b)).toBe(true);
+    });
+
+    it('ignores highlight array order within a page (Map-insertion-order artifact of mergeHighlights)', () => {
+      const page = (highlights) => ({ title: 'A', lastUpdated: '2024-01-01T00:00:00.000Z', highlights, deletedGroupIds: {} });
+      const a = emptyBlob({ pages: { 'https://a.test': page([{ groupId: 'g1', updatedAt: 1 }, { groupId: 'g2', updatedAt: 1 }]) } });
+      const b = emptyBlob({ pages: { 'https://a.test': page([{ groupId: 'g2', updatedAt: 1 }, { groupId: 'g1', updatedAt: 1 }]) } });
+      expect(isBlobContentEqual(a, b)).toBe(true);
+    });
+
+    it('ignores deletedUrls / deletedGroupIds key order (spread-merge artifact)', () => {
+      const a = emptyBlob({ deletedUrls: { 'https://a.test': 1, 'https://b.test': 2 } });
+      const b = emptyBlob({ deletedUrls: { 'https://b.test': 2, 'https://a.test': 1 } });
+      expect(isBlobContentEqual(a, b)).toBe(true);
+    });
+
+    it('still detects a real content difference (new highlight group added)', () => {
+      const page = (highlights) => ({ title: 'A', lastUpdated: '2024-01-01T00:00:00.000Z', highlights, deletedGroupIds: {} });
+      const a = emptyBlob({ pages: { 'https://a.test': page([{ groupId: 'g1', updatedAt: 1 }]) } });
+      const b = emptyBlob({ pages: { 'https://a.test': page([{ groupId: 'g1', updatedAt: 1 }, { groupId: 'g2', updatedAt: 1 }]) } });
+      expect(isBlobContentEqual(a, b)).toBe(false);
+    });
+  });
+
   describe('getCloudSyncStatus', () => {
     it('returns disabled defaults when nothing is stored', async () => {
       chrome.storage.local.get.mockResolvedValueOnce({});
@@ -124,6 +153,47 @@ describe('cloud-sync-service', () => {
       expect(chrome.storage.local.set).toHaveBeenCalledWith(
         expect.objectContaining({ cloudSyncLastSyncedAt: expect.any(Number), cloudSyncLastError: null })
       );
+    });
+
+    it('skips the PUT when the merged blob is unchanged from the fetched remote blob', async () => {
+      const code = generateSyncCode();
+      const { encryptionKey } = await deriveSyncKeys(code);
+
+      // Remote already holds exactly what local has (same page, reordered highlights
+      // to double-check the skip survives the order-insensitive comparison).
+      const remoteBlob = emptyBlob({
+        pages: {
+          'https://a.test': {
+            title: 'A',
+            lastUpdated: '2024-01-01T00:00:00.000Z',
+            highlights: [{ groupId: 'g2', updatedAt: 1 }, { groupId: 'g1', updatedAt: 1 }],
+            deletedGroupIds: {},
+          },
+        },
+      });
+      const envelope = await encryptBlob(remoteBlob, encryptionKey);
+
+      chrome.storage.local.get.mockImplementation((keys) => {
+        if (keys === null) {
+          return Promise.resolve({
+            'https://a.test': [{ groupId: 'g1', updatedAt: 1 }, { groupId: 'g2', updatedAt: 1 }],
+            'https://a.test_meta': { title: 'A', lastUpdated: '2024-01-01T00:00:00.000Z', deletedGroupIds: {} },
+          });
+        }
+        return Promise.resolve({ cloudSyncEnabled: true, cloudSyncCode: code });
+      });
+
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => envelope,
+      });
+
+      const result = await runCloudSync();
+
+      expect(result.success).toBe(true);
+      // Only the GET should have happened; the PUT is skipped because merged === remote.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('records the error and returns success:false when the fetch fails', async () => {

--- a/tests/crypto-utils.test.js
+++ b/tests/crypto-utils.test.js
@@ -1,0 +1,72 @@
+import {
+  generateSyncCode,
+  deriveSyncKeys,
+  encryptBlob,
+  decryptBlob,
+} from '../shared/crypto-utils.js';
+
+describe('crypto-utils', () => {
+  test('generateSyncCode produces a grouped, uppercase code', () => {
+    const code = generateSyncCode();
+    expect(code).toMatch(/^[0-9A-Z]{4}(-[0-9A-Z]{4}){12}$/);
+  });
+
+  test('generateSyncCode produces unique codes', () => {
+    const a = generateSyncCode();
+    const b = generateSyncCode();
+    expect(a).not.toBe(b);
+  });
+
+  test('deriveSyncKeys is deterministic for the same code', async () => {
+    const code = generateSyncCode();
+    const first = await deriveSyncKeys(code);
+    const second = await deriveSyncKeys(code);
+    expect(first.keyId).toBe(second.keyId);
+    expect(first.keyId).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  test('deriveSyncKeys yields different keyId for different codes', async () => {
+    const a = await deriveSyncKeys(generateSyncCode());
+    const b = await deriveSyncKeys(generateSyncCode());
+    expect(a.keyId).not.toBe(b.keyId);
+  });
+
+  test('deriveSyncKeys tolerates lowercase input and stray whitespace', async () => {
+    const code = generateSyncCode();
+    const messy = code.toLowerCase().replace(/-/g, ' ');
+    const canonical = await deriveSyncKeys(code);
+    const fromMessy = await deriveSyncKeys(messy);
+    expect(fromMessy.keyId).toBe(canonical.keyId);
+  });
+
+  test('encryptBlob/decryptBlob round-trips arbitrary JSON', async () => {
+    const code = generateSyncCode();
+    const { encryptionKey } = await deriveSyncKeys(code);
+    const original = { version: 1, pages: { 'https://example.com': { highlights: [{ groupId: 'a' }] } } };
+
+    const envelope = await encryptBlob(original, encryptionKey);
+    expect(envelope.v).toBe(1);
+    expect(typeof envelope.iv).toBe('string');
+    expect(typeof envelope.ciphertext).toBe('string');
+
+    const decrypted = await decryptBlob(envelope, encryptionKey);
+    expect(decrypted).toEqual(original);
+  });
+
+  test('decryptBlob fails with the wrong key', async () => {
+    const { encryptionKey: keyA } = await deriveSyncKeys(generateSyncCode());
+    const { encryptionKey: keyB } = await deriveSyncKeys(generateSyncCode());
+
+    const envelope = await encryptBlob({ hello: 'world' }, keyA);
+    await expect(decryptBlob(envelope, keyB)).rejects.toThrow();
+  });
+
+  test('two encryptions of the same blob use different IVs/ciphertext', async () => {
+    const { encryptionKey } = await deriveSyncKeys(generateSyncCode());
+    const blob = { a: 1 };
+    const e1 = await encryptBlob(blob, encryptionKey);
+    const e2 = await encryptBlob(blob, encryptionKey);
+    expect(e1.iv).not.toBe(e2.iv);
+    expect(e1.ciphertext).not.toBe(e2.ciphertext);
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,20 @@
 import { jest } from '@jest/globals';
+import { webcrypto } from 'node:crypto';
+import { TextEncoder, TextDecoder } from 'node:util';
 import chrome from '../mocks/chrome.js';
 global.jest = jest;
 global.chrome = chrome;
+
+// jsdom's built-in `crypto` only implements getRandomValues, not subtle (Web Crypto).
+// Cloud sync's crypto-utils.js needs subtle (HKDF/AES-GCM), so swap in Node's WebCrypto impl.
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+  globalThis.TextDecoder = TextDecoder;
+}

--- a/tests/sync-service.test.js
+++ b/tests/sync-service.test.js
@@ -175,6 +175,14 @@ describe('sync-service', () => {
       expect(result.deletedGroupIds).toHaveProperty('g1');
       expect(result.deletedGroupIds).toHaveProperty('g2');
     });
+
+    it('should keep the newer tombstone when both sides deleted the same highlight', () => {
+      const now = Date.now();
+      const local = { deletedGroupIds: { g1: now - 1000 } };
+      const remote = { deletedGroupIds: { g1: now - 3000 } };
+      const result = mergeHighlights(local, remote);
+      expect(result.deletedGroupIds.g1).toBe(now - 1000);
+    });
   });
 
   // ===================================================================

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,76 @@
+# text-highlighter-sync Worker
+
+Backend for the cloud sync feature described in
+[`arch-docs/cloudflare-kv-based-sync-design.md`](../arch-docs/cloudflare-kv-based-sync-design.md).
+It is a ~50 line Worker that stores/returns opaque encrypted blobs in a single
+KV namespace — all encryption happens on the extension side
+(`shared/crypto-utils.js`); this Worker never sees plaintext highlights or the
+user's sync code.
+
+Deployment requires your own Cloudflare account (free tier is enough) and
+cannot be done on your behalf — the steps below need to be run locally.
+
+## 1. Install wrangler and log in
+
+```bash
+cd worker
+npm install -g wrangler   # or: npx wrangler <command> for every step below
+wrangler login
+```
+
+## 2. Create the KV namespace
+
+```bash
+wrangler kv namespace create SYNC_KV
+```
+
+This prints an `id`. Copy it into `wrangler.toml`, replacing
+`REPLACE_WITH_KV_NAMESPACE_ID`.
+
+## 3. Deploy
+
+```bash
+wrangler deploy
+```
+
+This prints your Worker's URL, something like:
+
+```
+https://text-highlighter-sync.<your-subdomain>.workers.dev
+```
+
+## 4. Wire the URL into the extension
+
+Replace the placeholder in **both** of these locations with the URL from
+step 3 (no trailing slash):
+
+- [`constants/cloud-sync-config.js`](../constants/cloud-sync-config.js) — `CLOUD_SYNC_ENDPOINT_BASE`
+- `host_permissions` in [`manifest.json`](../manifest.json) and [`manifest-firefox.json`](../manifest-firefox.json) — as `https://text-highlighter-sync.<your-subdomain>.workers.dev/*`
+
+Then rebuild (`npm run deploy` / `npm run deploy:firefox`).
+
+## Manual smoke test
+
+```bash
+BASE=https://text-highlighter-sync.<your-subdomain>.workers.dev
+KEY=$(node -e "console.log(crypto.randomBytes(16).toString('hex'))")
+
+curl -i "$BASE/blob/$KEY"                       # expect 404
+curl -i -X PUT "$BASE/blob/$KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"v":1,"iv":"AAAA","ciphertext":"AAAA"}'   # expect 204
+curl -i "$BASE/blob/$KEY"                       # expect 200 + the JSON above
+curl -i -X DELETE "$BASE/blob/$KEY"              # expect 204
+```
+
+## Free tier limits to be aware of
+
+- KV: 100k reads/day, 1,000 writes/day (per namespace, shared across all
+  users), 1GB storage, 25MB max value size.
+- Workers: 100,000 requests/day, 10ms CPU time/invocation.
+
+The extension batches sync into a single blob push per sync cycle (not per
+highlight edit) specifically to stay well under the 1,000 writes/day cap —
+see the design doc for the reasoning. Rate limiting / abuse protection is
+intentionally not implemented in `src/index.js` v1; add it if usage patterns
+ever show a need (see "1차 구현 범위와 이후 과제" in the design doc).

--- a/worker/README.md
+++ b/worker/README.md
@@ -63,6 +63,17 @@ curl -i "$BASE/blob/$KEY"                       # expect 200 + the JSON above
 curl -i -X DELETE "$BASE/blob/$KEY"              # expect 204
 ```
 
+## Storage cleanup (TTL)
+
+Every `PUT` sets a 1-year `expirationTtl` on the KV entry. As long as at least
+one paired device keeps syncing (even with no content changes — the client
+skips no-op pushes, but a stale blob compared against fresh local data is
+never a no-op, so it gets re-pushed with a fresh TTL automatically), the blob
+never expires. Only truly abandoned sync codes (no device pushes for a full
+year — e.g. after "Forget Code" is used, which never calls `DELETE`) age out
+on their own, reclaiming free-tier KV storage without any explicit cleanup
+job or per-key last-accessed tracking (KV doesn't expose that).
+
 ## Free tier limits to be aware of
 
 - KV: 100k reads/day, 1,000 writes/day (per namespace, shared across all

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,68 @@
+// Cloudflare Worker backing the "cloud sync" feature (see
+// arch-docs/cloudflare-kv-based-sync-design.md). This is a thin, unauthenticated
+// proxy over a single KV namespace: the extension client encrypts everything
+// client-side (shared/crypto-utils.js) before it ever reaches here, and the
+// keyId in the URL path *is* the access token (derived from the user's own
+// sync code, never sent to or known by this Worker).
+//
+// Deployment: see worker/README.md. Requires only a Cloudflare free-tier
+// account and `wrangler` — no other services.
+
+const MAX_BODY_BYTES = 1_000_000; // Basic guardrail against accidental huge payloads, not abuse defense.
+const KEY_ID_PATTERN = /^\/blob\/([a-f0-9]{32})$/;
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const match = url.pathname.match(KEY_ID_PATTERN);
+
+    if (!match) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const keyId = match[1];
+    const kvKey = `blob:${keyId}`;
+
+    if (request.method === 'GET') {
+      const value = await env.SYNC_KV.get(kvKey);
+      if (value === null) {
+        return new Response('Not Found', { status: 404 });
+      }
+      return new Response(value, { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    if (request.method === 'PUT') {
+      const body = await request.text();
+      if (new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES) {
+        return new Response('Payload Too Large', { status: 413 });
+      }
+
+      let envelope;
+      try {
+        envelope = JSON.parse(body);
+      } catch (e) {
+        return new Response('Invalid JSON body', { status: 400 });
+      }
+      if (typeof envelope.iv !== 'string' || typeof envelope.ciphertext !== 'string') {
+        return new Response('Invalid envelope shape', { status: 400 });
+      }
+
+      await env.SYNC_KV.put(kvKey, body);
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === 'DELETE') {
+      await env.SYNC_KV.delete(kvKey);
+      return new Response(null, { status: 204 });
+    }
+
+    return jsonResponse({ error: 'Method Not Allowed' }, 405);
+  },
+};

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -10,6 +10,10 @@
 
 const MAX_BODY_BYTES = 1_000_000; // Basic guardrail against accidental huge payloads, not abuse defense.
 const KEY_ID_PATTERN = /^\/blob\/([a-f0-9]{32})$/;
+// Every successful PUT refreshes this TTL, so any device that's still syncing keeps its
+// blob alive indefinitely. Only truly abandoned codes (no device pushes for a full year)
+// age out, reclaiming free-tier KV storage without any explicit cleanup job.
+const BLOB_TTL_SECONDS = 60 * 60 * 24 * 365;
 
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -54,7 +58,7 @@ export default {
         return new Response('Invalid envelope shape', { status: 400 });
       }
 
-      await env.SYNC_KV.put(kvKey, body);
+      await env.SYNC_KV.put(kvKey, body, { expirationTtl: BLOB_TTL_SECONDS });
       return new Response(null, { status: 204 });
     }
 

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,9 @@
+name = "text-highlighter-sync"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+# Created via `wrangler kv namespace create SYNC_KV` — replace `id` with the
+# id it prints. See ../README.md for the full deployment walkthrough.
+kv_namespaces = [
+  { binding = "SYNC_KV", id = "REPLACE_WITH_KV_NAMESPACE_ID" }
+]

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -5,5 +5,5 @@ compatibility_date = "2025-01-01"
 # Created via `wrangler kv namespace create SYNC_KV` — replace `id` with the
 # id it prints. See ../README.md for the full deployment walkthrough.
 kv_namespaces = [
-  { binding = "SYNC_KV", id = "REPLACE_WITH_KV_NAMESPACE_ID" }
+  { binding = "SYNC_KV", id = "35ac01b55fb548ee862722725c3b67a9" }
 ]


### PR DESCRIPTION
## Summary
- Adds an opt-in Cloudflare Worker + KV backed cloud sync, end-to-end encrypted client-side (HKDF + AES-GCM), as an alternative sync path for browsers/platforms where `browser.storage.sync` isn't available (notably Firefox Android).
- Existing browser-sync (`storage.sync`) is left untouched and keeps working independently; cloud sync is a separate opt-in toggle in settings.
- Reuses the existing `mergeHighlights` conflict-resolution logic from `background/sync-service.js` for per-page merging, extended with page-level (URL) and settings-level merging across the whole synced blob.
- Follow-up hardening on top of the initial implementation:
  - Skip the KV `PUT` entirely when the merged blob is unchanged from the fetched remote blob (order-insensitive comparison), to stay well under the free tier's shared 1,000 writes/day cap.
  - 1-year `expirationTtl` on every KV write so abandoned sync codes (e.g. after "Forget Code", which never calls `DELETE`) self-clean without a cron job.

## Test plan
- [x] `npm test` — 136/136 passing (added unit tests for `isBlobContentEqual` order-insensitivity and the push-skip behavior in `runCloudSync`)
- [x] Manually smoke-tested the deployed Worker (`GET`/`PUT`/`DELETE` round trip) against the live `text-highlighter-sync.cuspymd.workers.dev` endpoint
- [ ] Manual verification on a real Firefox Android device (multi-device pairing, pull-merge-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)