### PR TITLE
fix: selection icon shows black background on some sites

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -475,8 +475,6 @@
   border: 1px solid rgba(255, 255, 255, 0.36) !important;
   border-radius: 10px !important;
   box-shadow: var(--th-shadow-2) !important;
-  backdrop-filter: blur(8px) !important;
-  -webkit-backdrop-filter: blur(8px) !important;
   transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s !important;
   display: flex !important;
   align-items: center !important;
@@ -506,6 +504,8 @@
 
 .text-highlighter-selection-icon img {
   display: block !important;
+  background: transparent !important;
+  border: none !important;
   pointer-events: none !important;
   user-select: none !important;
   -webkit-user-drag: none !important;


### PR DESCRIPTION
## Summary
- On sites like wafer.ai's blog, the text-selection highlight icon rendered with a solid black background instead of its intended translucent white pill.
- Two separate causes were found and fixed in `styles.css`:
  - `.text-highlighter-selection-icon img` had no background rule, so a host page's own global `img` styling (e.g. a dark lazy-load placeholder background) showed through the icon's transparent PNG. Fixed by explicitly setting `background: transparent !important; border: none !important;`.
  - `.text-highlighter-selection-icon` used `backdrop-filter: blur(8px)`, which triggers a known Chrome compositing bug that paints solid black instead of blurring when the page behind has certain animated/GPU-composited content — even though the computed `background` stayed correct. Fixed by removing `backdrop-filter`/`-webkit-backdrop-filter` from that rule (the existing `rgba(255,255,255,0.8)` background already provides the translucent look).

## Test plan
- [x] Verified via DevTools on wafer.ai/blog/glm52-amd that the computed `background` was already correct but rendering was black, confirming the compositing-bug diagnosis.
- [x] Rebuilt `dist`/`dist-firefox` and manually reloaded the unpacked extension in Chrome and Firefox; icon now shows the correct translucent background on the affected page.
- [ ] Existing automated test suite (`npm test`) — not run in this environment (missing `node_modules`); this is a CSS-only change with no JS behavior affected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>