### PR TITLE
fix: mask cloud sync code and add clipboard copy fallback

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -275,8 +275,17 @@
   "cloudSyncCopyCode": {
     "message": "Copy"
   },
+  "cloudSyncShowCode": {
+    "message": "Show"
+  },
+  "cloudSyncHideCode": {
+    "message": "Hide"
+  },
   "cloudSyncCodeCopied": {
     "message": "Copied!"
+  },
+  "cloudSyncCopyFailed": {
+    "message": "Couldn't copy automatically. The code is now shown above - please copy it manually."
   },
   "cloudSyncEnabledLabel": {
     "message": "Cloud Sync"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -275,8 +275,17 @@
   "cloudSyncCopyCode": {
     "message": "복사"
   },
+  "cloudSyncShowCode": {
+    "message": "표시"
+  },
+  "cloudSyncHideCode": {
+    "message": "숨기기"
+  },
   "cloudSyncCodeCopied": {
     "message": "복사됨!"
+  },
+  "cloudSyncCopyFailed": {
+    "message": "자동으로 복사할 수 없습니다. 위에 코드가 표시되었으니 직접 복사해 주세요."
   },
   "cloudSyncEnabledLabel": {
     "message": "클라우드 동기화"

--- a/settings.html
+++ b/settings.html
@@ -459,6 +459,7 @@
           <div class="cloud-sync-code-row">
             <span data-i18n="cloudSyncYourCode">Your Sync Code</span>
             <code id="cloud-sync-code-display" class="cloud-sync-code-value"></code>
+            <button id="cloud-sync-toggle-visibility-btn" class="btn-icon" data-i18n="cloudSyncShowCode">Show</button>
             <button id="cloud-sync-copy-btn" class="btn-icon" data-i18n="cloudSyncCopyCode">Copy</button>
           </div>
           <p class="hint-text" data-i18n="cloudSyncSaveCodeWarning">

--- a/settings.js
+++ b/settings.js
@@ -391,12 +391,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   const cloudSyncPairBtn = document.getElementById('cloud-sync-pair-btn');
   const cloudSyncToggle = document.getElementById('cloud-sync-toggle');
   const cloudSyncCodeDisplay = document.getElementById('cloud-sync-code-display');
+  const cloudSyncToggleVisibilityBtn = document.getElementById('cloud-sync-toggle-visibility-btn');
   const cloudSyncCopyBtn = document.getElementById('cloud-sync-copy-btn');
   const cloudSyncStatusText = document.getElementById('cloud-sync-status-text');
   const cloudSyncNowBtn = document.getElementById('cloud-sync-now-btn');
   const cloudSyncResetBtn = document.getElementById('cloud-sync-reset-btn');
 
   let currentSyncCode = null;
+  let isSyncCodeVisible = false;
+
+  function maskSyncCode(code) {
+    const groups = code.split('-');
+    if (groups.length <= 2) return code;
+    return groups
+      .map((group, index) => (index === 0 || index === groups.length - 1 ? group : '•'.repeat(group.length)))
+      .join('-');
+  }
+
+  function renderSyncCodeDisplay() {
+    if (!currentSyncCode) return;
+    cloudSyncCodeDisplay.textContent = isSyncCodeVisible ? currentSyncCode : maskSyncCode(currentSyncCode);
+    cloudSyncToggleVisibilityBtn.textContent = browserAPI.i18n.getMessage(
+      isSyncCodeVisible ? 'cloudSyncHideCode' : 'cloudSyncShowCode'
+    ) || (isSyncCodeVisible ? 'Hide' : 'Show');
+  }
 
   function renderCloudSyncStatus(status) {
     cloudSyncToggle.checked = !!status.enabled;
@@ -414,12 +432,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function renderCloudSyncView(status) {
+    if (currentSyncCode !== status.code) {
+      isSyncCodeVisible = false;
+    }
     currentSyncCode = status.code;
 
     if (status.code) {
       cloudSyncSetup.style.display = 'none';
       cloudSyncConnected.style.display = '';
-      cloudSyncCodeDisplay.textContent = status.code;
+      renderSyncCodeDisplay();
       renderCloudSyncStatus(status);
     } else {
       cloudSyncSetup.style.display = '';
@@ -475,12 +496,53 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadCloudSyncStatus();
   });
 
+  cloudSyncToggleVisibilityBtn.addEventListener('click', () => {
+    isSyncCodeVisible = !isSyncCodeVisible;
+    renderSyncCodeDisplay();
+  });
+
+  async function copyTextToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (err) {
+        // Fall through to the legacy fallback below (e.g. unsupported on this
+        // Firefox for Android version - navigator.clipboard.writeText only
+        // landed there in Firefox 151, long after desktop).
+      }
+    }
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const success = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return success;
+    } catch (err) {
+      return false;
+    }
+  }
+
   cloudSyncCopyBtn.addEventListener('click', async () => {
     if (!currentSyncCode) return;
-    await navigator.clipboard.writeText(currentSyncCode);
-    const original = cloudSyncCopyBtn.textContent;
-    cloudSyncCopyBtn.textContent = browserAPI.i18n.getMessage('cloudSyncCodeCopied') || 'Copied!';
-    setTimeout(() => { cloudSyncCopyBtn.textContent = original; }, 1500);
+    const copied = await copyTextToClipboard(currentSyncCode);
+    if (copied) {
+      const original = cloudSyncCopyBtn.textContent;
+      cloudSyncCopyBtn.textContent = browserAPI.i18n.getMessage('cloudSyncCodeCopied') || 'Copied!';
+      setTimeout(() => { cloudSyncCopyBtn.textContent = original; }, 1500);
+    } else {
+      isSyncCodeVisible = true;
+      renderSyncCodeDisplay();
+      await showAlertModal(
+        browserAPI.i18n.getMessage('cloudSyncCopyFailed') ||
+          "Couldn't copy automatically. The code is now shown above - please copy it manually."
+      );
+    }
   });
 
   cloudSyncNowBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- Mask the cloud sync code in Settings by default (only the first/last groups shown), with a Show/Hide toggle, since it's already exposed via the Copy button.
- Add an `execCommand('copy')` fallback for browsers where `navigator.clipboard.writeText` isn't available (e.g. Firefox for Android, which only gained support in v151), auto-revealing the code for manual copy if both copy methods fail.
- Add corresponding `ko`/`en` locale strings (`cloudSyncShowCode`, `cloudSyncHideCode`, `cloudSyncCopyFailed`).

## Test plan
- [ ] Load the extension, generate a sync code in Settings, confirm the code renders masked (first/last group visible) by default
- [ ] Click "Show"/"Hide" and confirm it toggles the full code correctly
- [ ] Click "Copy" and confirm the code is copied and button shows "Copied!"
- [ ] Simulate `navigator.clipboard` failure (e.g. via devtools) and confirm it falls back to `execCommand('copy')`, and if that also fails, the code auto-reveals with an alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)