### PR TITLE
fix: add CORS headers to sync worker responses

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -15,20 +15,39 @@ const KEY_ID_PATTERN = /^\/blob\/([a-f0-9]{32})$/;
 // age out, reclaiming free-tier KV storage without any explicit cleanup job.
 const BLOB_TTL_SECONDS = 60 * 60 * 24 * 365;
 
+// The keyId in the URL *is* the access token (see file header) - there's no cookie or
+// origin-based auth to protect, so a permissive CORS policy is safe. It's also required:
+// some browsers (e.g. Firefox for Android) enforce CORS on extension background fetches
+// even when host_permissions would normally exempt them, so every response - including
+// errors and preflight - needs these headers or the client never sees the real status.
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
   });
+}
+
+function textResponse(body, status) {
+  return new Response(body, { status, headers: CORS_HEADERS });
 }
 
 export default {
   async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
     const url = new URL(request.url);
     const match = url.pathname.match(KEY_ID_PATTERN);
 
     if (!match) {
-      return new Response('Not Found', { status: 404 });
+      return textResponse('Not Found', 404);
     }
 
     const keyId = match[1];
@@ -37,34 +56,34 @@ export default {
     if (request.method === 'GET') {
       const value = await env.SYNC_KV.get(kvKey);
       if (value === null) {
-        return new Response('Not Found', { status: 404 });
+        return textResponse('Not Found', 404);
       }
-      return new Response(value, { headers: { 'Content-Type': 'application/json' } });
+      return new Response(value, { headers: { 'Content-Type': 'application/json', ...CORS_HEADERS } });
     }
 
     if (request.method === 'PUT') {
       const body = await request.text();
       if (new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES) {
-        return new Response('Payload Too Large', { status: 413 });
+        return textResponse('Payload Too Large', 413);
       }
 
       let envelope;
       try {
         envelope = JSON.parse(body);
       } catch (e) {
-        return new Response('Invalid JSON body', { status: 400 });
+        return textResponse('Invalid JSON body', 400);
       }
       if (typeof envelope.iv !== 'string' || typeof envelope.ciphertext !== 'string') {
-        return new Response('Invalid envelope shape', { status: 400 });
+        return textResponse('Invalid envelope shape', 400);
       }
 
       await env.SYNC_KV.put(kvKey, body, { expirationTtl: BLOB_TTL_SECONDS });
-      return new Response(null, { status: 204 });
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
 
     if (request.method === 'DELETE') {
       await env.SYNC_KV.delete(kvKey);
-      return new Response(null, { status: 204 });
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
 
     return jsonResponse({ error: 'Method Not Allowed' }, 405);


### PR DESCRIPTION
## Summary
- Android sees `CORS Missing Allow Origin` on the sync worker's `/blob/:id` endpoint (reported when tapping "Generate New Code"), even for a plain 404 on a brand-new code.
- Root cause: `worker/src/index.js` never sent `Access-Control-Allow-Origin`. On desktop this was masked because extension background-script fetches are exempt from CORS given `host_permissions`, but Firefox for Android still enforces CORS on those requests, so every response (success or error) was blocked before the client's JS ever saw it.
- Fix: add `Access-Control-Allow-Origin: *` (plus allowed methods/headers) to every response, including error responses, and handle `OPTIONS` preflight. The keyId in the URL is already the sole access token (no cookie/origin-based auth), so a permissive CORS policy doesn't weaken the security model.

## Test plan
- [ ] Deploy the updated worker (`wrangler deploy` from `worker/`)
- [ ] On Firefox for Android, tap "Generate New Code" in Settings and confirm it completes without console CORS errors
- [ ] Confirm existing desktop Chrome/Firefox sync flows (generate, pair, manual sync, reset) still work

## Note
This worker change needs to be deployed (`wrangler deploy`) to take effect — merging the PR alone doesn't redeploy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)