### PR TITLE
i18n: add missing cloud sync translations for es, ja, zh

### DIFF
--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -247,5 +247,68 @@
   },
   "colorChangeWarning": {
     "message": "Los cambios no afectan a los resaltados existentes."
+  },
+  "cloudSyncSection": {
+    "message": "Sincronización en la Nube (Beta)"
+  },
+  "cloudSyncIntro": {
+    "message": "Sincroniza los resaltados entre dispositivos mediante una copia de seguridad cifrada en la nube, para plataformas (como Firefox para Android) donde la sincronización del navegador no está disponible. Tus datos se cifran en este dispositivo antes de subirlos; el código de sincronización es la única forma de descifrarlos."
+  },
+  "cloudSyncGenerateCode": {
+    "message": "Generar Nuevo Código"
+  },
+  "cloudSyncPairCodePlaceholder": {
+    "message": "Introduce el código de sincronización de otro dispositivo"
+  },
+  "cloudSyncPairCodeButton": {
+    "message": "Conectar"
+  },
+  "cloudSyncInvalidCode": {
+    "message": "Ese código de sincronización no parece correcto. Compruébalo e inténtalo de nuevo."
+  },
+  "cloudSyncYourCode": {
+    "message": "Tu Código de Sincronización"
+  },
+  "cloudSyncSaveCodeWarning": {
+    "message": "Guarda este código en un lugar seguro. Si lo pierdes, estos datos no se podrán recuperar."
+  },
+  "cloudSyncCopyCode": {
+    "message": "Copiar"
+  },
+  "cloudSyncShowCode": {
+    "message": "Mostrar"
+  },
+  "cloudSyncHideCode": {
+    "message": "Ocultar"
+  },
+  "cloudSyncCodeCopied": {
+    "message": "¡Copiado!"
+  },
+  "cloudSyncCopyFailed": {
+    "message": "No se pudo copiar automáticamente. El código se muestra arriba; cópialo manualmente."
+  },
+  "cloudSyncEnabledLabel": {
+    "message": "Sincronización en la Nube"
+  },
+  "cloudSyncNowButton": {
+    "message": "Sincronizar Ahora"
+  },
+  "cloudSyncSyncing": {
+    "message": "Sincronizando..."
+  },
+  "cloudSyncNeverSynced": {
+    "message": "Aún no sincronizado"
+  },
+  "cloudSyncLastSyncedPrefix": {
+    "message": "Última sincronización: "
+  },
+  "cloudSyncErrorPrefix": {
+    "message": "Error de sincronización: "
+  },
+  "cloudSyncResetButton": {
+    "message": "Olvidar Código"
+  },
+  "cloudSyncResetConfirm": {
+    "message": "Esto desconecta este dispositivo y olvida permanentemente el código de sincronización. Los datos ya subidos a la nube permanecerán a menos que también los restablezcas desde otro dispositivo conectado. ¿Continuar?"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -247,5 +247,68 @@
   },
   "colorChangeWarning": {
     "message": "既存のハイライトには影響しません。"
+  },
+  "cloudSyncSection": {
+    "message": "クラウド同期（ベータ版）"
+  },
+  "cloudSyncIntro": {
+    "message": "ブラウザ同期が利用できない環境（Android版Firefoxなど）向けに、暗号化されたクラウドバックアップでデバイス間のハイライトを同期します。データはアップロード前にこのデバイスで暗号化され、同期コードだけが復号の手段です。"
+  },
+  "cloudSyncGenerateCode": {
+    "message": "新しいコードを生成"
+  },
+  "cloudSyncPairCodePlaceholder": {
+    "message": "他のデバイスの同期コードを入力"
+  },
+  "cloudSyncPairCodeButton": {
+    "message": "接続"
+  },
+  "cloudSyncInvalidCode": {
+    "message": "同期コードが正しくないようです。確認してもう一度お試しください。"
+  },
+  "cloudSyncYourCode": {
+    "message": "あなたの同期コード"
+  },
+  "cloudSyncSaveCodeWarning": {
+    "message": "このコードは安全な場所に保管してください。紛失するとデータを復元できません。"
+  },
+  "cloudSyncCopyCode": {
+    "message": "コピー"
+  },
+  "cloudSyncShowCode": {
+    "message": "表示"
+  },
+  "cloudSyncHideCode": {
+    "message": "非表示"
+  },
+  "cloudSyncCodeCopied": {
+    "message": "コピーしました！"
+  },
+  "cloudSyncCopyFailed": {
+    "message": "自動コピーに失敗しました。コードが上に表示されていますので、手動でコピーしてください。"
+  },
+  "cloudSyncEnabledLabel": {
+    "message": "クラウド同期"
+  },
+  "cloudSyncNowButton": {
+    "message": "今すぐ同期"
+  },
+  "cloudSyncSyncing": {
+    "message": "同期中..."
+  },
+  "cloudSyncNeverSynced": {
+    "message": "まだ同期されていません"
+  },
+  "cloudSyncLastSyncedPrefix": {
+    "message": "最終同期: "
+  },
+  "cloudSyncErrorPrefix": {
+    "message": "同期エラー: "
+  },
+  "cloudSyncResetButton": {
+    "message": "コードを削除"
+  },
+  "cloudSyncResetConfirm": {
+    "message": "このデバイスの接続を解除し、同期コードを完全に削除します。他の接続済みデバイスからリセットしない限り、すでにクラウドにアップロードされたデータはそのまま残ります。続行しますか？"
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -247,5 +247,68 @@
   },
   "colorChangeWarning": {
     "message": "更改不会影响已有的高亮显示。"
+  },
+  "cloudSyncSection": {
+    "message": "云同步（测试版）"
+  },
+  "cloudSyncIntro": {
+    "message": "通过加密的云备份在设备间同步高亮内容，适用于浏览器同步不可用的平台（例如 Android 版 Firefox）。数据会在上传前在本设备上加密，只有同步码才能解密。"
+  },
+  "cloudSyncGenerateCode": {
+    "message": "生成新代码"
+  },
+  "cloudSyncPairCodePlaceholder": {
+    "message": "输入其他设备的同步码"
+  },
+  "cloudSyncPairCodeButton": {
+    "message": "连接"
+  },
+  "cloudSyncInvalidCode": {
+    "message": "同步码看起来不正确，请检查后重试。"
+  },
+  "cloudSyncYourCode": {
+    "message": "我的同步码"
+  },
+  "cloudSyncSaveCodeWarning": {
+    "message": "请妥善保存此代码，一旦丢失将无法恢复此数据。"
+  },
+  "cloudSyncCopyCode": {
+    "message": "复制"
+  },
+  "cloudSyncShowCode": {
+    "message": "显示"
+  },
+  "cloudSyncHideCode": {
+    "message": "隐藏"
+  },
+  "cloudSyncCodeCopied": {
+    "message": "已复制！"
+  },
+  "cloudSyncCopyFailed": {
+    "message": "无法自动复制。代码已显示在上方，请手动复制。"
+  },
+  "cloudSyncEnabledLabel": {
+    "message": "云同步"
+  },
+  "cloudSyncNowButton": {
+    "message": "立即同步"
+  },
+  "cloudSyncSyncing": {
+    "message": "同步中..."
+  },
+  "cloudSyncNeverSynced": {
+    "message": "尚未同步"
+  },
+  "cloudSyncLastSyncedPrefix": {
+    "message": "上次同步: "
+  },
+  "cloudSyncErrorPrefix": {
+    "message": "同步错误: "
+  },
+  "cloudSyncResetButton": {
+    "message": "忘记代码"
+  },
+  "cloudSyncResetConfirm": {
+    "message": "这将断开此设备的连接，并永久忘记同步码。除非在其他已连接的设备上重置，否则已上传到云端的数据仍将保留。是否继续？"
   }
 }


### PR DESCRIPTION
## Summary
- The Cloud Sync feature's 21 message keys (`cloudSyncSection`, `cloudSyncIntro`, etc.) were only ever localized in `en`/`ko`; `es`, `ja`, and `zh` never got translations.
- The most recent additions (`cloudSyncShowCode`, `cloudSyncHideCode`, `cloudSyncCopyFailed` from #99) widened the gap further.
- Added translations for all 21 missing keys to `_locales/es/messages.json`, `_locales/ja/messages.json`, and `_locales/zh/messages.json` based on the English source text.
- Verified all 5 locale files now have an identical set of 104 message keys.

## Test plan
- [x] `node -e` JSON.parse validation on all 5 locale files
- [x] Programmatic key-set diff confirming en/es/ja/ko/zh all match exactly
- [ ] Manual spot-check of translated strings in the Settings UI (Cloud Sync section) for es/ja/zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)