### PR TITLE
fix: show cloud sync size limit details

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Text Highlighter"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "This disconnects this device and permanently forgets the sync code. Continue?"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "Your sync data is $1. The current limit is $2.",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Resaltador de Texto"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "Esto desconecta este dispositivo y olvida permanentemente el código de sincronización. ¿Continuar?"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "Tus datos de sincronización ocupan $1. El límite actual es $2.",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: テキストハイライター"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "このデバイスの接続を解除し、同期コードを完全に削除します。続行しますか？"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "同期データは $1 です。現在の上限は $2 です。",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 텍스트 하이라이터"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "이 기기의 연결이 해제되고 동기화 코드를 완전히 잊어버립니다. 계속하시겠습니까?"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "동기화 데이터가 $1입니다. 현재 제한은 $2입니다.",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: Text Highlighter"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "Isso desconecta este dispositivo e esquece permanentemente o código de sincronização. Continuar?"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "Seus dados de sincronização têm $1. O limite atual é $2.",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,4 +1,5 @@
-{  "extensionName": {
+{
+  "extensionName": {
     "message": "Marks: 文本高亮器"
   },
   "extensionDescription": {
@@ -310,5 +311,9 @@
   },
   "cloudSyncResetConfirm": {
     "message": "这将断开此设备的连接，并永久忘记同步码。是否继续？"
+  },
+  "cloudSyncDataTooLargeStatus": {
+    "message": "你的同步数据为 $1。当前限制为 $2。",
+    "description": "Shown when encrypted cloud sync upload data exceeds the current size limit. $1 is current size, $2 is max size."
   }
 }

--- a/background/cloud-sync-service.js
+++ b/background/cloud-sync-service.js
@@ -22,10 +22,42 @@ const LOCAL_ONLY_KEYS = new Set([
   CLOUD_SYNC_KEYS.CODE,
   CLOUD_SYNC_KEYS.LAST_SYNCED_AT,
   CLOUD_SYNC_KEYS.LAST_ERROR,
+  CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS,
   CLOUD_SYNC_KEYS.DELETED_URLS,
   CLOUD_SYNC_KEYS.SETTINGS_UPDATED_AT,
   'settings', // storage.sync settings payload key, never present in storage.local but guard anyway
 ]);
+
+const CLOUD_SYNC_DATA_TOO_LARGE = 'CLOUD_SYNC_DATA_TOO_LARGE';
+
+function byteLength(text) {
+  return new TextEncoder().encode(text).byteLength;
+}
+
+function formatBytes(bytes) {
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(2)} MB`;
+  if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
+  return `${bytes} bytes`;
+}
+
+function createCloudSyncSizeError(currentBytes, maxBytes) {
+  const error = new Error(
+    `Cloud sync data too large (${formatBytes(currentBytes)} / ${formatBytes(maxBytes)} limit)`
+  );
+  error.code = CLOUD_SYNC_DATA_TOO_LARGE;
+  error.currentBytes = currentBytes;
+  error.maxBytes = maxBytes;
+  return error;
+}
+
+function getErrorDetails(error) {
+  if (error.code !== CLOUD_SYNC_DATA_TOO_LARGE) return null;
+  return {
+    code: error.code,
+    currentBytes: error.currentBytes,
+    maxBytes: error.maxBytes,
+  };
+}
 
 function emptyBlob() {
   return {
@@ -250,8 +282,9 @@ async function fetchRemoteBlob(keyId, encryptionKey, { allowMissingRemote = true
 async function pushRemoteBlob(keyId, encryptionKey, blob) {
   const envelope = await encryptBlob(blob, encryptionKey);
   const body = JSON.stringify(envelope);
-  if (new TextEncoder().encode(body).byteLength > CLOUD_SYNC_MAX_BODY_BYTES) {
-    throw new Error('Cloud sync data too large');
+  const bodyBytes = byteLength(body);
+  if (bodyBytes > CLOUD_SYNC_MAX_BODY_BYTES) {
+    throw createCloudSyncSizeError(bodyBytes, CLOUD_SYNC_MAX_BODY_BYTES);
   }
 
   const res = await fetch(`${CLOUD_SYNC_ENDPOINT_BASE}/blob/${keyId}`, {
@@ -268,6 +301,7 @@ export async function getCloudSyncStatus() {
     CLOUD_SYNC_KEYS.CODE,
     CLOUD_SYNC_KEYS.LAST_SYNCED_AT,
     CLOUD_SYNC_KEYS.LAST_ERROR,
+    CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS,
   ]);
 
   return {
@@ -275,6 +309,7 @@ export async function getCloudSyncStatus() {
     code: result[CLOUD_SYNC_KEYS.CODE] || null,
     lastSyncedAt: result[CLOUD_SYNC_KEYS.LAST_SYNCED_AT] || null,
     lastError: result[CLOUD_SYNC_KEYS.LAST_ERROR] || null,
+    lastErrorDetails: result[CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS] || null,
   };
 }
 
@@ -314,13 +349,18 @@ export async function runCloudSync({ allowMissingRemote = true, forcePush = fals
     await browserAPI.storage.local.set({
       [CLOUD_SYNC_KEYS.LAST_SYNCED_AT]: Date.now(),
       [CLOUD_SYNC_KEYS.LAST_ERROR]: null,
+      [CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS]: null,
     });
     debugLog('Cloud sync completed.');
     return { success: true };
   } catch (e) {
     debugLog('Cloud sync failed:', e.message);
-    await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.LAST_ERROR]: e.message });
-    return { success: false, error: e.message };
+    const errorDetails = getErrorDetails(e);
+    await browserAPI.storage.local.set({
+      [CLOUD_SYNC_KEYS.LAST_ERROR]: e.message,
+      [CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS]: errorDetails,
+    });
+    return { success: false, error: e.message, errorDetails };
   }
 }
 
@@ -372,6 +412,7 @@ export async function resetCloudSyncCode() {
     [CLOUD_SYNC_KEYS.CODE]: null,
     [CLOUD_SYNC_KEYS.LAST_SYNCED_AT]: null,
     [CLOUD_SYNC_KEYS.LAST_ERROR]: null,
+    [CLOUD_SYNC_KEYS.LAST_ERROR_DETAILS]: null,
   });
 }
 

--- a/constants/storage-keys.js
+++ b/constants/storage-keys.js
@@ -18,6 +18,7 @@ export const CLOUD_SYNC_KEYS = {
   CODE: 'cloudSyncCode',
   LAST_SYNCED_AT: 'cloudSyncLastSyncedAt',
   LAST_ERROR: 'cloudSyncLastError',
+  LAST_ERROR_DETAILS: 'cloudSyncLastErrorDetails',
   DELETED_URLS: 'cloudSyncDeletedUrls',
   SETTINGS_UPDATED_AT: 'cloudSyncSettingsUpdatedAt',
 };

--- a/settings.js
+++ b/settings.js
@@ -416,11 +416,29 @@ document.addEventListener('DOMContentLoaded', async () => {
     ) || (isSyncCodeVisible ? 'Hide' : 'Show');
   }
 
+  function formatBytes(bytes) {
+    if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(2)} MB`;
+    if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
+    return `${bytes} bytes`;
+  }
+
+  function formatCloudSyncError(status) {
+    const details = status.lastErrorDetails;
+    if (details && details.code === 'CLOUD_SYNC_DATA_TOO_LARGE') {
+      const currentSize = formatBytes(details.currentBytes);
+      const maxSize = formatBytes(details.maxBytes);
+      const message = browserAPI.i18n.getMessage('cloudSyncDataTooLargeStatus', [currentSize, maxSize]) ||
+        `Your sync data is ${currentSize}. The current limit is ${maxSize}.`;
+      return `${browserAPI.i18n.getMessage('cloudSyncErrorPrefix') || 'Sync error: '}${message}`;
+    }
+    return `${browserAPI.i18n.getMessage('cloudSyncErrorPrefix') || 'Sync error: '}${status.lastError}`;
+  }
+
   function renderCloudSyncStatus(status) {
     cloudSyncToggle.checked = !!status.enabled;
 
     if (status.lastError) {
-      cloudSyncStatusText.textContent = `${browserAPI.i18n.getMessage('cloudSyncErrorPrefix') || 'Sync error: '}${status.lastError}`;
+      cloudSyncStatusText.textContent = formatCloudSyncError(status);
       cloudSyncStatusText.classList.add('cloud-sync-error-text');
     } else if (status.lastSyncedAt) {
       cloudSyncStatusText.textContent = `${browserAPI.i18n.getMessage('cloudSyncLastSyncedPrefix') || 'Last synced: '}${new Date(status.lastSyncedAt).toLocaleString()}`;

--- a/tests/cloud-sync-service.test.js
+++ b/tests/cloud-sync-service.test.js
@@ -141,7 +141,13 @@ describe('cloud-sync-service', () => {
     it('returns disabled defaults when nothing is stored', async () => {
       chrome.storage.local.get.mockResolvedValueOnce({});
       const status = await getCloudSyncStatus();
-      expect(status).toEqual({ enabled: false, code: null, lastSyncedAt: null, lastError: null });
+      expect(status).toEqual({
+        enabled: false,
+        code: null,
+        lastSyncedAt: null,
+        lastError: null,
+        lastErrorDetails: null,
+      });
     });
   });
 
@@ -236,6 +242,36 @@ describe('cloud-sync-service', () => {
       expect(chrome.storage.local.set).toHaveBeenCalledWith(
         expect.objectContaining({ cloudSyncLastError: expect.any(String) })
       );
+    });
+
+    it('includes current and maximum byte sizes when the upload data is too large', async () => {
+      const code = generateSyncCode();
+      chrome.storage.local.get.mockImplementation((keys) => {
+        if (keys === null) {
+          return Promise.resolve({
+            'https://large.test': [{ groupId: 'g1', text: 'x'.repeat(1_050_000), updatedAt: 1 }],
+            'https://large.test_meta': { title: 'Large', lastUpdated: '2024-01-01T00:00:00.000Z', deletedGroupIds: {} },
+          });
+        }
+        return Promise.resolve({ cloudSyncEnabled: true, cloudSyncCode: code });
+      });
+      global.fetch = jest.fn().mockResolvedValueOnce({ status: 404, ok: false });
+
+      const result = await runCloudSync();
+
+      expect(result.success).toBe(false);
+      expect(result.errorDetails).toEqual({
+        code: 'CLOUD_SYNC_DATA_TOO_LARGE',
+        currentBytes: expect.any(Number),
+        maxBytes: 1_000_000,
+      });
+      expect(result.errorDetails.currentBytes).toBeGreaterThan(result.errorDetails.maxBytes);
+      expect(result.error).toContain('1.00 MB limit');
+      expect(global.fetch).toHaveBeenCalledTimes(1); // GET only; oversized payload is rejected before PUT.
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(expect.objectContaining({
+        cloudSyncLastError: expect.stringContaining('Cloud sync data too large'),
+        cloudSyncLastErrorDetails: result.errorDetails,
+      }));
     });
   });
 


### PR DESCRIPTION
## Summary

- Include structured size-limit details when cloud sync upload data exceeds the current 1 MB limit.
- Show a clearer Settings-page message with the current sync data size and the maximum allowed size.
- Add localized strings for the new message across supported locales.
- Add regression coverage for oversized cloud sync data.

## Verification

- `npm test`
- `npm run deploy`

## Notes

This does not change the 1 MB cloud sync limit; it only makes the failure easier for users to understand.
