### PR TITLE
fix: close delete/tombstone race and use sender tab for save title

### DIFF
--- a/background/message-router.js
+++ b/background/message-router.js
@@ -9,6 +9,7 @@ import {
   cleanupEmptyHighlightData,
   cleanupTombstones,
   saveSettingsToSync,
+  recordCloudSyncTombstones,
 } from './sync-service.js';
 import {
   getCloudSyncStatus,
@@ -167,8 +168,9 @@ async function handleSaveHighlights(message, sender) {
     await syncSaveHighlights(message.url, message.highlights, metaData.title, metaData.lastUpdated);
     return successResponse();
   } else {
-    await syncRemoveHighlights(message.url);
+    const tombstoneRecorded = await syncRemoveHighlights(message.url);
     await cleanupEmptyHighlightData(message.url);
+    if (!tombstoneRecorded) await recordCloudSyncTombstones([message.url]);
     return successResponse();
   }
 }
@@ -200,8 +202,9 @@ async function handleDeleteHighlight(message) {
     }
     return successResponse({ highlights: updatedHighlights });
   } else {
-    await syncRemoveHighlights(url);
+    const tombstoneRecorded = await syncRemoveHighlights(url);
     await cleanupEmptyHighlightData(url);
+    if (!tombstoneRecorded) await recordCloudSyncTombstones([url]);
     if (message.notifyRefresh) {
       await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: [] });
     }
@@ -211,8 +214,9 @@ async function handleDeleteHighlight(message) {
 
 async function handleClearAllHighlights(message) {
   const { url } = message;
-  await syncRemoveHighlights(url);
+  const tombstoneRecorded = await syncRemoveHighlights(url);
   await cleanupEmptyHighlightData(url);
+  if (!tombstoneRecorded) await recordCloudSyncTombstones([url]);
   if (message.notifyRefresh) {
     await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: [] });
   }
@@ -279,9 +283,10 @@ async function handleDeleteAllHighlightedPages(_message) {
   }
 
   if (keysToDelete.length > 0) {
-    await clearAllSyncedHighlights(urls);
+    const tombstoneRecorded = await clearAllSyncedHighlights(urls);
     await browserAPI.storage.local.remove(keysToDelete);
     debugLog('All highlighted pages deleted:', keysToDelete);
+    if (!tombstoneRecorded) await recordCloudSyncTombstones(urls);
   }
 
   return successResponse({ deletedCount: keysToDelete.length / 2 });

--- a/background/message-router.js
+++ b/background/message-router.js
@@ -147,10 +147,7 @@ async function handleSaveShortcutColorMap(message) {
   return successResponse();
 }
 
-async function handleSaveHighlights(message) {
-  const tabs = await browserAPI.tabs.query({ active: true, currentWindow: true });
-  const currentTab = tabs[0];
-
+async function handleSaveHighlights(message, sender) {
   if (message.highlights.length > 0) {
     const saveData = {};
     saveData[message.url] = message.highlights;
@@ -159,7 +156,7 @@ async function handleSaveHighlights(message) {
 
     const result = await browserAPI.storage.local.get([`${message.url}${STORAGE_KEYS.META_SUFFIX}`]);
     const metaData = result[`${message.url}${STORAGE_KEYS.META_SUFFIX}`] || {};
-    metaData.title = currentTab.title;
+    if (sender && sender.tab) metaData.title = sender.tab.title;
     metaData.lastUpdated = new Date().toISOString();
 
     const metaSaveData = {};
@@ -170,8 +167,8 @@ async function handleSaveHighlights(message) {
     await syncSaveHighlights(message.url, message.highlights, metaData.title, metaData.lastUpdated);
     return successResponse();
   } else {
-    await cleanupEmptyHighlightData(message.url);
     await syncRemoveHighlights(message.url);
+    await cleanupEmptyHighlightData(message.url);
     return successResponse();
   }
 }
@@ -203,8 +200,8 @@ async function handleDeleteHighlight(message) {
     }
     return successResponse({ highlights: updatedHighlights });
   } else {
-    await cleanupEmptyHighlightData(url);
     await syncRemoveHighlights(url);
+    await cleanupEmptyHighlightData(url);
     if (message.notifyRefresh) {
       await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: [] });
     }
@@ -214,8 +211,8 @@ async function handleDeleteHighlight(message) {
 
 async function handleClearAllHighlights(message) {
   const { url } = message;
-  await cleanupEmptyHighlightData(url);
   await syncRemoveHighlights(url);
+  await cleanupEmptyHighlightData(url);
   if (message.notifyRefresh) {
     await broadcastToTabsByUrl(url, { action: 'refreshHighlights', highlights: [] });
   }
@@ -282,9 +279,9 @@ async function handleDeleteAllHighlightedPages(_message) {
   }
 
   if (keysToDelete.length > 0) {
+    await clearAllSyncedHighlights(urls);
     await browserAPI.storage.local.remove(keysToDelete);
     debugLog('All highlighted pages deleted:', keysToDelete);
-    await clearAllSyncedHighlights(urls);
   }
 
   return successResponse({ deletedCount: keysToDelete.length / 2 });
@@ -355,14 +352,14 @@ const ACTION_HANDLERS = {
  * Call once at service worker startup (top-level, before any async code).
  */
 export function registerMessageRouter() {
-  browserAPI.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const handler = ACTION_HANDLERS[message.action];
     if (!handler) {
       sendResponse(errorResponse(`Unknown action: ${message.action}`));
       return true;
     }
 
-    handler(message)
+    handler(message, sender)
       .then(result => sendResponse(result))
       .catch(e => {
         debugLog('Error in message handler:', e);

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -155,8 +155,12 @@ export async function saveSettingsToSync() {
 /**
  * Record a local tombstone for cloud sync (Cloudflare KV blob), independent of
  * browser storage.sync's own tombstone bookkeeping (sync_meta.deletedUrls).
+ * Returns whether the write succeeded so callers can retry (e.g. once the
+ * page's own highlight payload has been freed from storage.local, which is
+ * the most common reason this small write would fail: local storage sitting
+ * at or near its quota).
  */
-async function recordCloudSyncTombstones(urls) {
+export async function recordCloudSyncTombstones(urls) {
   try {
     const result = await browserAPI.storage.local.get(CLOUD_SYNC_KEYS.DELETED_URLS);
     const deletedUrls = result[CLOUD_SYNC_KEYS.DELETED_URLS] || {};
@@ -164,8 +168,10 @@ async function recordCloudSyncTombstones(urls) {
     for (const url of urls) deletedUrls[url] = now;
     cleanupTombstones(deletedUrls);
     await browserAPI.storage.local.set({ [CLOUD_SYNC_KEYS.DELETED_URLS]: deletedUrls });
+    return true;
   } catch (e) {
     debugLog('Failed to record cloud sync tombstone(s):', e.message);
+    return false;
   }
 }
 
@@ -239,12 +245,19 @@ export async function syncSaveHighlights(url, highlights, title, lastUpdated) {
   }
 }
 
+/**
+ * @returns {Promise<boolean>} whether the cloud sync tombstone write succeeded.
+ *   If false, the caller should retry recordCloudSyncTombstones([url]) after
+ *   freeing local storage (e.g. after cleanupEmptyHighlightData), since the
+ *   most likely failure cause — storage.local at/near quota — no longer
+ *   applies once the page's own highlight payload has been removed.
+ */
 export async function syncRemoveHighlights(url) {
   // Recorded first (a local-only write) so a runCloudSync() that races this
   // function always sees the tombstone before it sees the highlights gone from
   // storage.local, and correctly treats the page as deleted instead of
   // resurrecting it from the still-present remote copy.
-  await recordCloudSyncTombstones([url]);
+  const tombstoneRecorded = await recordCloudSyncTombstones([url]);
 
   const syncKey = urlToSyncKey(url);
   try {
@@ -266,6 +279,8 @@ export async function syncRemoveHighlights(url) {
   } catch (e) {
     debugLog('Failed to remove highlights from sync:', e.message);
   }
+
+  return tombstoneRecorded;
 }
 
 export async function cleanupEmptyHighlightData(url) {
@@ -293,11 +308,14 @@ async function applyUserDeletionFromSync(url) {
  *   clearing (may be a superset of sync_meta.pages, e.g. pages that never fit the 8KB
  *   per-item browser sync limit). Used to record cloud sync tombstones for every page,
  *   since the Cloudflare KV blob has no per-item size limit of its own.
+ * @returns {Promise<boolean>} whether the cloud sync tombstone write succeeded.
+ *   If false, the caller should retry recordCloudSyncTombstones(localUrls) after
+ *   freeing local storage — see syncRemoveHighlights for why.
  */
 export async function clearAllSyncedHighlights(localUrls = []) {
   // Recorded first, before any storage.sync round-trip or local removal — see
   // the comment in syncRemoveHighlights for why the ordering matters.
-  await recordCloudSyncTombstones(localUrls);
+  const tombstoneRecorded = await recordCloudSyncTombstones(localUrls);
 
   try {
     const meta = await getSyncMeta();
@@ -319,6 +337,8 @@ export async function clearAllSyncedHighlights(localUrls = []) {
   } catch (e) {
     debugLog('Failed to clear synced highlights:', e.message);
   }
+
+  return tombstoneRecorded;
 }
 
 /**

--- a/background/sync-service.js
+++ b/background/sync-service.js
@@ -240,6 +240,12 @@ export async function syncSaveHighlights(url, highlights, title, lastUpdated) {
 }
 
 export async function syncRemoveHighlights(url) {
+  // Recorded first (a local-only write) so a runCloudSync() that races this
+  // function always sees the tombstone before it sees the highlights gone from
+  // storage.local, and correctly treats the page as deleted instead of
+  // resurrecting it from the still-present remote copy.
+  await recordCloudSyncTombstones([url]);
+
   const syncKey = urlToSyncKey(url);
   try {
     const meta = await getSyncMeta();
@@ -260,8 +266,6 @@ export async function syncRemoveHighlights(url) {
   } catch (e) {
     debugLog('Failed to remove highlights from sync:', e.message);
   }
-
-  await recordCloudSyncTombstones([url]);
 }
 
 export async function cleanupEmptyHighlightData(url) {
@@ -291,6 +295,10 @@ async function applyUserDeletionFromSync(url) {
  *   since the Cloudflare KV blob has no per-item size limit of its own.
  */
 export async function clearAllSyncedHighlights(localUrls = []) {
+  // Recorded first, before any storage.sync round-trip or local removal — see
+  // the comment in syncRemoveHighlights for why the ordering matters.
+  await recordCloudSyncTombstones(localUrls);
+
   try {
     const meta = await getSyncMeta();
     const syncKeysToRemove = meta.pages.map(p => p.syncKey);
@@ -311,8 +319,6 @@ export async function clearAllSyncedHighlights(localUrls = []) {
   } catch (e) {
     debugLog('Failed to clear synced highlights:', e.message);
   }
-
-  await recordCloudSyncTombstones(localUrls);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Record the cloud sync tombstone (`recordCloudSyncTombstones`) before removing local highlight data in `syncRemoveHighlights`/`clearAllSyncedHighlights`, and reorder the matching call sites in `message-router.js`. Previously a concurrent `runCloudSync()` (15-min alarm, startup, or manual trigger) could land in the window between the local delete and the tombstone write, see the deleted page as untouched, and resurrect the deleted highlights from the still-present remote copy.
- Pass `sender` through the message router to `handleSaveHighlights`, which now uses `sender.tab.title` instead of `tabs.query({active: true, currentWindow: true})`. The query could resolve to the wrong tab in a multi-window setup, or throw (`tabs[0]` undefined) after highlights were already saved locally but before metadata/sync updates ran.

## Test plan
- [x] `npm test` — all 151 relevant unit/integration tests pass (`message-router.test.js`, `sync-service.test.js`, `tab-broadcast.test.js`, etc.); pre-existing Playwright `.spec.js` failures under Jest are unrelated to this change and present on `main` too.
- [ ] Manual smoke test: delete a highlight/page while cloud sync is enabled and confirm it doesn't reappear after the next sync cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)