### PR TITLE
fix: adopt null shortcutColorMap from cloud sync

### DIFF
--- a/background/settings-service.js
+++ b/background/settings-service.js
@@ -442,9 +442,16 @@ export async function applySettingsFromSync(newSettings) {
     await broadcastToAllTabs({ action: 'setSelectionControlsVisibility', visible: newSettings.selectionControlsVisible });
   }
 
-  if (newSettings.shortcutColorMap) {
+  // `null` is a value here ("no custom mapping"), not an absent field, so it has to be
+  // adopted like any other. Skipping it leaves this device's own map in place while
+  // runCloudSync still stamps the sender's settings timestamp onto it — two devices then
+  // claim the same timestamp while disagreeing on content, and push at each other on every
+  // sync cycle. Storage keeps the null so buildLocalBlob reads it back as null and both
+  // sides converge; the in-memory copy falls back to the defaults the way
+  // loadShortcutColorMap does, because callers index into it directly.
+  if (newSettings.shortcutColorMap !== undefined) {
     await browserAPI.storage.local.set({ [STORAGE_KEYS.SHORTCUT_COLOR_MAP]: newSettings.shortcutColorMap });
-    shortcutColorMap = newSettings.shortcutColorMap;
+    shortcutColorMap = newSettings.shortcutColorMap || { ...DEFAULT_SHORTCUT_COLOR_MAP };
   }
 
   return { colorsChanged };

--- a/tests/settings-service.test.js
+++ b/tests/settings-service.test.js
@@ -10,6 +10,7 @@ import {
   applySettingsFromSync,
   broadcastSettingsToTabs,
   loadCustomColors,
+  getShortcutColorMap,
 } from '../background/settings-service.js';
 
 describe('settings-service', () => {
@@ -226,6 +227,47 @@ describe('settings-service', () => {
     it('should return colorsChanged: false when settings contain no color data', async () => {
       const result = await applySettingsFromSync({});
       expect(result.colorsChanged).toBe(false);
+    });
+
+    it('should adopt a shortcutColorMap from sync', async () => {
+      await applySettingsFromSync({ shortcutColorMap: { command_slot_1: 'custom_1' } });
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+        shortcutColorMap: { command_slot_1: 'custom_1' },
+      });
+      expect(getShortcutColorMap()).toEqual({ command_slot_1: 'custom_1' });
+    });
+
+    // A null map means "no custom mapping" and must be adopted like any other value.
+    // Skipping it left two devices claiming the same settings timestamp while disagreeing
+    // on content, which made every sync cycle push a blob at the other device forever.
+    it('should adopt a null shortcutColorMap instead of keeping the local one', async () => {
+      await applySettingsFromSync({ shortcutColorMap: { command_slot_1: 'custom_1' } });
+      chrome.storage.local.set.mockClear();
+
+      await applySettingsFromSync({ shortcutColorMap: null });
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ shortcutColorMap: null });
+    });
+
+    it('should keep the in-memory shortcut map usable after adopting null', async () => {
+      await applySettingsFromSync({ shortcutColorMap: null });
+
+      const map = getShortcutColorMap();
+      expect(map).not.toBeNull();
+      expect(() => Object.keys(map)).not.toThrow();
+    });
+
+    it('should leave the shortcut map untouched when the field is absent', async () => {
+      await applySettingsFromSync({ shortcutColorMap: { command_slot_2: 'custom_2' } });
+      chrome.storage.local.set.mockClear();
+
+      await applySettingsFromSync({ minimapVisible: true });
+
+      expect(chrome.storage.local.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ shortcutColorMap: expect.anything() }),
+      );
+      expect(getShortcutColorMap()).toEqual({ command_slot_2: 'custom_2' });
     });
   });
 


### PR DESCRIPTION
## Problem

Cloud sync was writing to Cloudflare KV on essentially every 15-minute cycle for affected users, even with no highlight or settings changes. Observed on the deployed Worker: ~78 writes/day against 22 sync users, i.e. a PUT on roughly 20% of all sync cycles.

## Root cause

`applySettingsFromSync` guarded the shortcut map with a truthiness check:

```js
if (newSettings.shortcutColorMap) {
```

A `null` map is a real value — it means "no custom mapping" — but it was treated as an absent field and skipped. Meanwhile `runCloudSync` stamps the sender's settings timestamp onto the receiving device unconditionally (`cloud-sync-service.js:353`).

So a device that adopted someone else's settings copied the timestamp but kept its own shortcut map. Both devices then claimed the *same* settings timestamp while disagreeing on content. `mergeBlobs` breaks that tie with a strict `>` (`cloud-sync-service.js:139`), which evaluates to "mine wins" on *both* devices, so neither ever adopted the other and each pushed its own blob forever.

Reproducing condition: one device has configured shortcut colors, the other never has, and the device *without* a map is the one that most recently changed any setting.

Beyond the write volume, settings sync silently never converged for these users.

### Verified

Simulating two devices over 20 alternating sync cycles with the real `mergeBlobs` / `isBlobContentEqual`, modelling `applySettingsFromSync`'s adoption semantics:

| | before |
|---|---|
| receiving device adopts `minimapVisible` | yes |
| receiving device keeps its own `shortcutColorMap` | yes (null skipped) |
| both devices' settings timestamp | identical |
| PUTs over 20 cycles | **17** |
| control — newer side *has* a map | ≤2 |
| control — identical settings | 0 |

## Fix

Adopt the field whenever it is present, `null` included. Storage keeps the `null` so `buildLocalBlob` reads it back as `null` and both sides converge on identical content.

The in-memory copy falls back to the defaults, mirroring `loadShortcutColorMap` — `createOrUpdateContextMenus` (`settings-service.js:180`) and the command handler (`context-menu.js:55`) index into the map directly and would throw on `null`.

## Tests

Four cases added to `tests/settings-service.test.js`: a map is adopted, a `null` map is adopted rather than skipped, the in-memory map stays usable after adopting `null`, and an absent field still leaves the map untouched.

Full suite: 155 passed, 13 suites.

## Not addressed here

The tie-breaking in `mergeBlobs` still resolves to "mine wins" on both sides, so any future source of equal-timestamp divergence would reproduce the same loop. Legacy users whose settings timestamp is still `0` on both devices (upgraded from a pre-cloud-sync version, never changed a setting) can also hit it. Worth a follow-up, but it needs a merge strategy that cannot discard a user's custom colors, so it is kept out of this change.

Also unverified: whether this bug accounts for *all* of the observed write volume. The Worker is stateless and unlogged, so that can only be confirmed by watching the write rate after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
