### PR TITLE
chore: link .agents/skills into .claude/skills for Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,11 @@ Release builds force debug off through `scripts/version-deploy.cjs` by updating:
 
 - `scripts/deploy.cjs`: copies production files into browser-specific dist directories
 - `scripts/version-deploy.cjs`: version bump + release build + zip packaging
+- `scripts/link-skills.cjs`: links `.claude/skills` to `.agents/skills` for Claude Code
 
 ## Skills
 
+Repository skills live in `.agents/skills/`, which is tracked in git. Claude Code only discovers skills under `.claude/skills/`, so run `npm run link-skills` once per clone to link `.claude/skills` to it instead of duplicating the files. Add new skills under `.agents/skills/<name>/SKILL.md` only.
+
 Reusable release workflow skill:
-- `skills/version-release/SKILL.md`
+- `.agents/skills/version-release/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The Selection Controls feature (floating highlight icon on text selection) is au
 
 ## Development
 
+### Agent Skills
+
+Repository skills live in `.agents/skills/`, which is tracked in git and shared across agent tools. Claude Code only discovers skills under `.claude/skills/`, so link the two rather than keeping a second copy:
+
+```bash
+npm run link-skills
+```
+
+This creates `.claude/skills` as a link to `.agents/skills` (a directory junction on Windows, which needs no elevation). Run it once per clone — `.claude/` is gitignored, so the link is local to your machine. It is idempotent and safe to re-run. Restart Claude Code afterwards for the skills to be picked up.
+
+Add new skills to `.agents/skills/<name>/SKILL.md` only; the link exposes them automatically.
+
 ### Testing
 
 Run E2E tests using Playwright:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --no-cache",
     "deploy": "node ./scripts/deploy.cjs",
     "deploy:firefox": "node ./scripts/deploy.cjs firefox",
-    "version-deploy": "node ./scripts/version-deploy.cjs"
+    "version-deploy": "node ./scripts/version-deploy.cjs",
+    "link-skills": "node ./scripts/link-skills.cjs"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/link-skills.cjs
+++ b/scripts/link-skills.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Links .claude/skills -> .agents/skills so Claude Code can discover the
+// repository's skills without keeping a second copy of them.
+// .agents/skills is the tracked source of truth; .claude/ is gitignored.
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const source = path.join(root, '.agents', 'skills');
+const link = path.join(root, '.claude', 'skills');
+
+if (!fs.existsSync(source)) {
+  console.error(`Source not found: ${source}`);
+  process.exit(1);
+}
+
+const existing = fs.existsSync(link) && fs.lstatSync(link);
+if (existing && existing.isSymbolicLink()) {
+  if (path.resolve(fs.realpathSync(link)) === path.resolve(source)) {
+    console.log('Already linked: .claude/skills -> .agents/skills');
+    process.exit(0);
+  }
+  fs.unlinkSync(link);
+} else if (existing) {
+  console.error('.claude/skills exists as a real directory. Move its contents into .agents/skills and remove it first.');
+  process.exit(1);
+}
+
+fs.mkdirSync(path.dirname(link), { recursive: true });
+// 'junction' works on Windows without elevation and is ignored elsewhere.
+fs.symlinkSync(source, link, process.platform === 'win32' ? 'junction' : 'dir');
+console.log('Linked: .claude/skills -> .agents/skills');

--- a/scripts/link-skills.cjs
+++ b/scripts/link-skills.cjs
@@ -10,21 +10,56 @@ const root = path.resolve(__dirname, '..');
 const source = path.join(root, '.agents', 'skills');
 const link = path.join(root, '.claude', 'skills');
 
+// Windows junctions store an absolute target, so moving or renaming the clone
+// leaves a dangling entry behind. Probe with lstat rather than existsSync,
+// which follows the link and reports a dangling one as missing.
+function lstatOrNull(target) {
+  try {
+    return fs.lstatSync(target);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function realpathOrNull(target) {
+  try {
+    return fs.realpathSync(target);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function removeLink(target) {
+  try {
+    fs.unlinkSync(target);
+  } catch (err) {
+    // Windows reports directory reparse points as EPERM/EISDIR for unlink.
+    if (err.code !== 'EPERM' && err.code !== 'EISDIR') throw err;
+    fs.rmdirSync(target);
+  }
+}
+
 if (!fs.existsSync(source)) {
   console.error(`Source not found: ${source}`);
   process.exit(1);
 }
 
-const existing = fs.existsSync(link) && fs.lstatSync(link);
-if (existing && existing.isSymbolicLink()) {
-  if (path.resolve(fs.realpathSync(link)) === path.resolve(source)) {
+const existing = lstatOrNull(link);
+if (existing && !existing.isSymbolicLink()) {
+  console.error('.claude/skills exists as a real directory. Move its contents into .agents/skills and remove it first.');
+  process.exit(1);
+}
+
+if (existing) {
+  const current = realpathOrNull(link);
+  if (current && current === fs.realpathSync(source)) {
     console.log('Already linked: .claude/skills -> .agents/skills');
     process.exit(0);
   }
-  fs.unlinkSync(link);
-} else if (existing) {
-  console.error('.claude/skills exists as a real directory. Move its contents into .agents/skills and remove it first.');
-  process.exit(1);
+  // Dangling, or pointing somewhere else: replace it.
+  removeLink(link);
 }
 
 fs.mkdirSync(path.dirname(link), { recursive: true });


### PR DESCRIPTION
## Problem

Repository skills live in `.agents/skills/` so they stay tracked in git and shared across agent tools. Claude Code only scans `.claude/skills/`, so it never sees them — the workaround so far would be keeping a second copy of every skill, which drifts and doubles maintenance.

Verified against the installed Claude Code 2.1.246: the binary contains `.claude/skills` as a lookup path and no `.agents` directory equivalent. `skillsPath`/`skillsPaths` exist only as plugin-manifest fields, so there is no settings.json way to add a search path.

## Change

- Add `scripts/link-skills.cjs` and an `npm run link-skills` script that points `.claude/skills` at `.agents/skills` — a directory junction on Windows (no elevation required), a symlink elsewhere. Idempotent, and it refuses to clobber a real `.claude/skills` directory.
- `.claude/` stays gitignored, so the link is per-clone local setup rather than a committed artifact (junctions store absolute targets and would not be portable anyway).
- Document the one-time step in README under Development.
- Fix the stale skill path in AGENTS.md (`skills/version-release/` → `.agents/skills/version-release/`) and list the new script.

Adding a skill now means creating `.agents/skills/<name>/SKILL.md` and nothing else.

## Testing

No runtime/extension code is touched — this is tooling and docs only.

- `npm run link-skills` creates the junction; re-running reports `Already linked` and makes no change.
- `SKILL.md` reads correctly through the link, and `git status` stays clean of `.claude/`.

One caveat worth flagging: I could not confirm end-to-end that Claude Code's skill loader follows the junction, because a nested headless CLI run fails to authenticate while the desktop app holds the OAuth session. Filesystem-level transparency is confirmed; the loader behaviour needs a manual check (restart Claude Code, confirm `/version-release` appears). If it does not, the fallback is to invert the link — real files in `.claude/skills/`, junction at `.agents/skills` — which additionally needs `.gitignore` changed to `.claude/*` plus `!.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
